### PR TITLE
Adds blank_or methods and tests

### DIFF
--- a/lib/errgonomic.rb
+++ b/lib/errgonomic.rb
@@ -56,4 +56,39 @@ class Object
     return block.call if blank?
     self
   end
+
+  # Returns the receiver if it is blank, otherwise raises a NotPresentError.
+  # This method is helpful to enforce expectations where blank objects are required.
+  #
+  # @param message [String] The error message to raise if the receiver is not blank.
+  # @return [Object] The receiver if it is blank, otherwise raises a NotPresentError.
+  def blank_or_raise(message)
+    raise Errgonomic::NotPresentError, message unless blank?
+    self
+  end
+
+  # Returns the receiver if it is blank, otherwise returns the given value.
+  #
+  # @param value [Object] The value to return if the receiver is not blank.
+  # @return [Object] The receiver if it is blank, otherwise the given value.
+  def blank_or(value)
+    # TBD whether this is *too* strict
+    if value.class != self.class && self.class != NilClass
+      raise Errgonomic::TypeMismatchError, "Type mismatch: default value is a #{value.class} but original was a #{self.class}"
+    end
+
+    return self if blank?
+
+    value
+  end
+
+  # Returns the receiver if it is blank, otherwise returns the result of the
+  # block.
+  #
+  # @param block [Proc] The block to call if the receiver is not blank.
+  # @return [Object] The receiver if it is blank, otherwise the result of the block.
+  def blank_or_else(&block)
+    return block.call unless blank?
+    self
+  end
 end

--- a/spec/errgonomic_spec.rb
+++ b/spec/errgonomic_spec.rb
@@ -43,4 +43,51 @@ RSpec.describe Errgonomic do
       expect({foo: "bar"}.present_or({foo: "baz"})).to eq({foo: "bar"})
     end
   end
+
+  describe "blank_or_raise" do
+    it "raises an error for present objects" do
+      expect { "bar".blank_or_raise("foo") }.to raise_error(Errgonomic::NotPresentError)
+      expect { ["baz"].blank_or_raise("foo") }.to raise_error(Errgonomic::NotPresentError)
+      expect { { foo: "bar" }.blank_or_raise("foo") }.to raise_error(Errgonomic::NotPresentError)
+    end
+
+    it "returns the value itself for blank types" do
+      expect(nil.blank_or_raise("foo")).to eq(nil)
+      expect([].blank_or_raise("foo")).to eq([])
+      expect({}.blank_or_raise("foo")).to eq({})
+    end
+  end
+
+  describe "blank_or" do
+    it "returns the receiver for blank objects" do
+      expect(nil.blank_or("foo")).to eq(nil)
+      expect([].blank_or(["foo"])).to eq([])
+      expect({}.blank_or({ foo: "bar" })).to eq({})
+    end
+
+    it "returns the default value for present objects" do
+      expect("bar".blank_or("foo")).to eq("foo")
+      expect(["baz"].blank_or(["foo"])).to eq(["foo"])
+      expect({ foo: "bar" }.blank_or({ foo: "baz" })).to eq({ foo: "baz" })
+    end
+
+    it "enforces type checks similar to present_or" do
+      expect { "bar".blank_or(["foo"]) }.to raise_error(Errgonomic::TypeMismatchError)
+      expect { [].blank_or("foo") }.to raise_error(Errgonomic::TypeMismatchError)
+    end
+  end
+
+  describe "blank_or_else" do
+    it "returns the receiver for blank objects" do
+      expect(nil.blank_or_else { "foo" }).to eq(nil)
+      expect([].blank_or_else { ["foo"] }).to eq([])
+      expect({}.blank_or_else { { foo: "bar" } }).to eq({})
+    end
+
+    it "returns the result of the block for present objects" do
+      expect("bar".blank_or_else { "foo" }).to eq("foo")
+      expect(["baz"].blank_or_else { ["foo"] }).to eq(["foo"])
+      expect({ foo: "bar" }.blank_or_else { { foo: "baz" } }).to eq({ foo: "baz" })
+    end
+  end
 end


### PR DESCRIPTION
I find `blank?` very useful to avoid using weird conditional chains. This PR adds the counter-hand of `present_or` with `blank_or` methods.