### PR TITLE
Adds type methods for objects

### DIFF
--- a/lib/errgonomic.rb
+++ b/lib/errgonomic.rb
@@ -5,6 +5,9 @@ require_relative 'errgonomic/version' unless defined?(Errgonomic::VERSION)
 # A more opinionated blend with Rails presence.
 require_relative 'errgonomic/presence'
 
+# Bring in a subtle and manual type checker.
+require_relative 'errgonomic/type'
+
 # Bring in our Option and Result.
 require_relative 'errgonomic/option'
 require_relative 'errgonomic/result'

--- a/lib/errgonomic/type.rb
+++ b/lib/errgonomic/type.rb
@@ -8,9 +8,9 @@ class Object
   # @param message [String] Optional error message to raise if type doesn't match.
   # @return [Object] The receiver if it is of the expected type.
   # @example
-  #   "hello".type_or_raise!(String)   # => "hello"
-  #   123.type_or_raise!(String)       # => raises TypeMismatchError
-  #   123.type_or_raise!(String, "Not a string")  # => raises TypeMismatchError with custom message
+  #   'hello'.type_or_raise!(String) #=> "hello"
+  #   123.type_or_raise!(String, "We need a string!") #=> raise Errgonomic::TypeMismatchError, "We need a string!"
+  #   123.type_or_raise!(String) #=> raise Errgonomic::TypeMismatchError, "Expected String but got Integer"
   def type_or_raise!(type, message = nil)
     message ||= "Expected #{type} but got #{self.class}"
     raise Errgonomic::TypeMismatchError, message unless is_a?(type)
@@ -26,8 +26,8 @@ class Object
   # @param default [Object] The value to return if type doesn't match.
   # @return [Object] The receiver if it is of the expected type, otherwise the default value.
   # @example
-  #   "hello".type_or(String, "default")  # => "hello"
-  #   123.type_or(String, "default")      # => "default"
+  #   'hello'.type_or(String, 'default')  # => "hello"
+  #   123.type_or(String, 'default')      # => "default"
   def type_or(type, default)
     return self if is_a?(type)
 
@@ -41,8 +41,8 @@ class Object
   # @param block [Proc] The block to call if type doesn't match.
   # @return [Object] The receiver if it is of the expected type, otherwise the block result.
   # @example
-  #   "hello".type_or_else(String) { "default" }  # => "hello"
-  #   123.type_or_else(String) { "default" }      # => "default"
+  #   'hello'.type_or_else(String) { 'default' }  # => "hello"
+  #   123.type_or_else(String) { 'default' }      # => "default"
   def type_or_else(type, &block)
     return self if is_a?(type)
 
@@ -55,9 +55,9 @@ class Object
   # @param message [String] Optional error message to raise if type matches.
   # @return [Object] The receiver if it is not of the specified type.
   # @example
-  #   "hello".not_type_or_raise!(Integer)  # => "hello"
-  #   123.not_type_or_raise!(Integer)      # => raises TypeMismatchError
-  #   123.not_type_or_raise!(Integer, "Not an integer")  # => raises TypeMismatchError with custom message
+  #   'hello'.not_type_or_raise!(Integer) #=> "hello"
+  #   123.not_type_or_raise!(Integer, "We dont want an integer!") #=> raise Errgonomic::TypeMismatchError, "We dont want an integer!"
+  #   123.not_type_or_raise!(Integer) #=> raise Errgonomic::TypeMismatchError, "Expected anything but Integer but got Integer"
   def not_type_or_raise!(type, message = nil)
     message ||= "Expected anything but #{type} but got #{self.class}"
     raise Errgonomic::TypeMismatchError, message if is_a?(type)

--- a/lib/errgonomic/type.rb
+++ b/lib/errgonomic/type.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class Object
+  # Returns the receiver if it matches the expected type, otherwise raises a TypeMismatchError.
+  # This is useful for enforcing type expectations in method arguments.
+  #
+  # @param type [Class] The expected type or module the receiver should be.
+  # @param message [String] Optional error message to raise if type doesn't match.
+  # @return [Object] The receiver if it is of the expected type.
+  def type_or_raise!(type, message = nil)
+    message ||= "Expected #{type} but got #{self.class}"
+    raise Errgonomic::TypeMismatchError, message unless is_a?(type)
+
+    self
+  end
+
+  alias_method :type_or_raise, :type_or_raise!
+
+  # Returns the receiver if it matches the expected type, otherwise returns the default value.
+  #
+  # @param type [Class] The expected type or module the receiver should be.
+  # @param default [Object] The value to return if type doesn't match.
+  # @return [Object] The receiver if it is of the expected type, otherwise the default value.
+  def type_or(type, default)
+    return self if is_a?(type)
+
+    default
+  end
+
+  # Returns the receiver if it matches the expected type, otherwise returns the result of the block.
+  # Useful when constructing the default value is expensive.
+  #
+  # @param type [Class] The expected type or module the receiver should be.
+  # @param block [Proc] The block to call if type doesn't match.
+  # @return [Object] The receiver if it is of the expected type, otherwise the block result.
+  def type_or_else(type, &block)
+    return self if is_a?(type)
+
+    block.call
+  end
+
+  # Returns the receiver if it does not match the expected type, otherwise raises a TypeMismatchError.
+  #
+  # @param type [Class] The type or module the receiver should not be.
+  # @param message [String] Optional error message to raise if type matches.
+  # @return [Object] The receiver if it is not of the specified type.
+  def not_type_or_raise!(type, message = nil)
+    message ||= "Expected anything but #{type} but got #{self.class}"
+    raise Errgonomic::TypeMismatchError, message if is_a?(type)
+
+    self
+  end
+end

--- a/lib/errgonomic/type.rb
+++ b/lib/errgonomic/type.rb
@@ -7,6 +7,10 @@ class Object
   # @param type [Class] The expected type or module the receiver should be.
   # @param message [String] Optional error message to raise if type doesn't match.
   # @return [Object] The receiver if it is of the expected type.
+  # @example
+  #   "hello".type_or_raise!(String)   # => "hello"
+  #   123.type_or_raise!(String)       # => raises TypeMismatchError
+  #   123.type_or_raise!(String, "Not a string")  # => raises TypeMismatchError with custom message
   def type_or_raise!(type, message = nil)
     message ||= "Expected #{type} but got #{self.class}"
     raise Errgonomic::TypeMismatchError, message unless is_a?(type)
@@ -14,13 +18,16 @@ class Object
     self
   end
 
-  alias_method :type_or_raise, :type_or_raise!
+  alias type_or_raise type_or_raise!
 
   # Returns the receiver if it matches the expected type, otherwise returns the default value.
   #
   # @param type [Class] The expected type or module the receiver should be.
   # @param default [Object] The value to return if type doesn't match.
   # @return [Object] The receiver if it is of the expected type, otherwise the default value.
+  # @example
+  #   "hello".type_or(String, "default")  # => "hello"
+  #   123.type_or(String, "default")      # => "default"
   def type_or(type, default)
     return self if is_a?(type)
 
@@ -33,6 +40,9 @@ class Object
   # @param type [Class] The expected type or module the receiver should be.
   # @param block [Proc] The block to call if type doesn't match.
   # @return [Object] The receiver if it is of the expected type, otherwise the block result.
+  # @example
+  #   "hello".type_or_else(String) { "default" }  # => "hello"
+  #   123.type_or_else(String) { "default" }      # => "default"
   def type_or_else(type, &block)
     return self if is_a?(type)
 
@@ -44,6 +54,10 @@ class Object
   # @param type [Class] The type or module the receiver should not be.
   # @param message [String] Optional error message to raise if type matches.
   # @return [Object] The receiver if it is not of the specified type.
+  # @example
+  #   "hello".not_type_or_raise!(Integer)  # => "hello"
+  #   123.not_type_or_raise!(Integer)      # => raises TypeMismatchError
+  #   123.not_type_or_raise!(Integer, "Not an integer")  # => raises TypeMismatchError with custom message
   def not_type_or_raise!(type, message = nil)
     message ||= "Expected anything but #{type} but got #{self.class}"
     raise Errgonomic::TypeMismatchError, message if is_a?(type)


### PR DESCRIPTION
Introduces a very similar API to `present_or` but for subtle type checking.

Useful when expecting a specific kind of object in an abstract setup.