### PR TITLE
do not implicitly serialize the Option and Result containers

### DIFF
--- a/lib/errgonomic.rb
+++ b/lib/errgonomic.rb
@@ -23,9 +23,11 @@ require_relative 'errgonomic/rails' if defined?(Rails::Railtie)
 module Errgonomic
   class Error < StandardError; end
 
+  class TypeError < ::TypeError; end
+
   class NotPresentError < Error; end
 
-  class TypeMismatchError < Error; end
+  class TypeMismatchError < TypeError; end
 
   class UnwrapError < Error
     def initialize(msg, value)
@@ -41,6 +43,8 @@ module Errgonomic
   class ResultRequiredError < Error; end
 
   class NotComparableError < StandardError; end
+
+  class SerializeError < TypeError; end
 
   # A little bit of control over how pedantic we are in our runtime type checks.
   def self.give_me_ambiguous_downstream_errors?

--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -321,6 +321,26 @@ module Errgonomic
         Some(other)
       end
 
+      # Refuse to serialize an unwrapped Option as a String. Options must be
+      # correctly handled to access their inner value.
+      #
+      # @example
+      #   None().to_s # => raise Errgonomic::SerializeError, "cannot serialize an unwrapped Option"
+      def to_s
+        raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Option'
+      end
+
+      # Refuse to serialize an unwrapped Option as JSON. Not only should we
+      # require that options be correctly handled to access their inner value,
+      # but without this we will get undefined structures from default
+      # Object#to_json implementations.
+      #
+      # @example
+      #   None().to_json # => raise Errgonomic::SerializeError, "cannot serialize an unwrapped Option"
+      def to_json(*_args)
+        raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Option'
+      end
+
       # filter
       # xor
       # insert

--- a/lib/errgonomic/rails/active_record_optional.rb
+++ b/lib/errgonomic/rails/active_record_optional.rb
@@ -53,19 +53,11 @@ module Errgonomic
       delegate :marked_for_destruction?, to: :value
       delegate :persisted?, to: :value
       delegate :touch_later, to: :value
-
-      def to_s
-        raise "Attempted to convert Some to String, please use Option API to safely work with internal value -- #{value}"
-      end
     end
 
     class None
       def nil?
         true
-      end
-
-      def to_s
-        raise 'Cannot convert None to String - please use Option API to safely work with internal value'
       end
     end
   end

--- a/lib/errgonomic/result.rb
+++ b/lib/errgonomic/result.rb
@@ -252,6 +252,28 @@ module Errgonomic
         @value = block.call(value)
         self
       end
+
+      # Refuse to serialize an unwrapped Result as a String. Results must be
+      # correctly handled to access their inner value.
+      #
+      # @example
+      #   Ok("").to_s # => raise Errgonomic::SerializeError, "cannot serialize an unwrapped Result"
+      #   Err("").to_s # => raise Errgonomic::SerializeError, "cannot serialize an unwrapped Result"
+      def to_s
+        raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Result'
+      end
+
+      # Refuse to serialize an unwrapped Result as JSON. Not only should we
+      # require that Results be correctly handled to access their inner value,
+      # but without this we will get undefined structures from default
+      # Object#to_json implementations.
+      #
+      # @example
+      #   Ok("").to_json # => raise Errgonomic::SerializeError, "cannot serialize an unwrapped Result"
+      #   Err("").to_json # => raise Errgonomic::SerializeError, "cannot serialize an unwrapped Result"
+      def to_json(*_args)
+        raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Result'
+      end
     end
 
     # The Ok variant.


### PR DESCRIPTION
Closes #7 

It does not make sense to serialize the outer Option or Result. The whole idea for this library is that the inner values must be accessed correctly, and once that has been done, the programmer has strong guarantees of correctness. That means throwing errors as early as possible, including a clear refusal to serialize unwrapped Option and Result.
