### PR TITLE
Result: map_err and deconstruct

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    errgonomic (0.5.1)
+    errgonomic (0.6.0)
       concurrent-ruby (~> 1.0)
 
 GEM
@@ -303,4 +303,4 @@ DEPENDENCIES
   yard-doctest (~> 0.1)
 
 BUNDLED WITH
-   2.6.9
+   2.6.6

--- a/gemset.nix
+++ b/gemset.nix
@@ -269,7 +269,7 @@
       path = ./.;
       type = "path";
     };
-    version = "0.5.1";
+    version = "0.6.0";
   };
   erubi = {
     groups = ["default" "development"];

--- a/lib/errgonomic/result.rb
+++ b/lib/errgonomic/result.rb
@@ -250,6 +250,17 @@ module Errgonomic
         Ok(block.call(value))
       end
 
+      # Map the Err(e) to an Err(f), preserving the Ok
+      #
+      # @example
+      #   Ok(:Alice).map_err { |_e| :Bob } # => Ok(:Alice)
+      #   Err(:bob).map_err { |e| e.capitalize } # => Err(:Bob)
+      def map_err(&block)
+        return self if ok?
+
+        Err(block.call(value))
+      end
+
       # Refuse to serialize an unwrapped Result as a String. Results must be
       # correctly handled to access their inner value.
       #
@@ -271,6 +282,30 @@ module Errgonomic
       def to_json(*_args)
         raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Result'
       end
+
+      # @example simple pattern match with variable capture of the value
+      #   result = Errgonomic::Result::Ok.new(1)
+      #   case result
+      #   in Errgonomic::Result::Ok, value
+      #     "Measurement is #{value}"
+      #   in Errgonomic::Result::Err, err
+      #     "Measurement is not available"
+      #   end # => "Measurement is 1"
+      #
+      # @example more advanced pattern match against the kind of value
+      #   result = Errgonomic::Result::Err.new(StandardError.new("nope"))
+      #   case result
+      #   in Errgonomic::Result::Ok, value
+      #     "Measurement is #{value}"
+      #   in Errgonomic::Result::Err, String => msg
+      #     "Measurement failed with a message: #{msg}"
+      #   in Errgonomic::Result::Err, Exception => e
+      #     "Measurement produced an exception -- #{e.class}: #{e}"
+      #   end # => "Measurement produced an exception -- StandardError: nope"
+      def deconstruct
+        [self, value]
+      end
+
     end
 
     # The Ok variant.

--- a/lib/errgonomic/version.rb
+++ b/lib/errgonomic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Errgonomic
-  VERSION = '0.5.1'
+  VERSION = '0.6.0'
 end


### PR DESCRIPTION
Surprised I went this long without `Result#map_err`, I really need to make a full checklist of Result methods and see what else may be missing.

Also `deconstruct` is pretty useful for [pattern-matching](https://docs.ruby-lang.org/en/3.4/syntax/pattern_matching_rdoc.html) on Result. Because Ruby has Exceptions, but exception-handling is optional, I find it fits the job that Errgonomic is doing to rescue certain (domain-applicable) exceptions, and return them with the Error side of a Result. Using deconstruct and Ruby pattern matching gives me a reasonable approximation of matching an enum in Rust.

```ruby
result = Errgonomic::Result::Err.new(StandardError.new("nope"))
case result
in Errgonomic::Result::Ok, value
  "Measurement is #{value}"
in Errgonomic::Result::Err, String => msg
  "Measurement failed with a message: #{msg}"
in Errgonomic::Result::Err, Exception => e
  "Measurement produced an exception -- #{e.class}: #{e}"
end # => "Measurement produced an exception -- StandardError: nope"
```

So far I think this is more _helpful_ than it is _uncanny valley._ But this whole gem kind of flirts with that space.