### PR TITLE
Option: present?/blank? follow the discriminant

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ end
 
 An unhandled Option refuses to leak into your output: `to_s` and `to_json` raise `Errgonomic::SerializeError`, so you handle the inner value deliberately rather than shipping `#<Errgonomic::Option::Some...>` to a user.
 
+Presence follows the discriminant, as in Rust: `Some` is `present?` and `None` is `blank?`, regardless of the wrapped value. So `Some(false).present?` and `Some(nil).present?` are both `true`. If you care about the inner value's own presence, unwrap it first.
+
 ### Result
 
 `Ok(value)` and `Err(error)` express an operation that may fail, again with the Rust combinators:

--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -78,6 +78,27 @@ module Errgonomic
 
       alias none_or? none_or
 
+      # Presence follows the discriminant, not the inner value: Some is
+      # present, None is blank. So Some(false) and Some(nil) are present,
+      # unlike their unwrapped values.
+      #
+      # @example
+      #   Some(1).present? # => true
+      #   Some(false).present? # => true
+      #   Some("").present? # => true
+      #   None().present? # => false
+      def present?
+        some?
+      end
+
+      # @example
+      #   None().blank? # => true
+      #   Some(1).blank? # => false
+      #   Some(nil).blank? # => false
+      def blank?
+        none?
+      end
+
       # return an Array with the contained value, if any
       # @example
       #   Some(1).to_a # => [1]

--- a/lib/errgonomic/rails/active_record_optional.rb
+++ b/lib/errgonomic/rails/active_record_optional.rb
@@ -35,7 +35,8 @@ module Errgonomic
   end
 end
 
-# do we need this since we alias present below?
+# Validates that an Option attribute is Some, analogous to a presence
+# validation on a plain attribute.
 class SomeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     record.errors.add(attribute, 'is invalid') unless value.some?
@@ -44,13 +45,6 @@ end
 
 module Errgonomic
   module Option
-    # In Rails, presence doubles as some-ness: present? means Some and
-    # blank? means None, so Options cooperate with presence-based code.
-    class Any
-      alias some? present?
-      alias none? blank?
-    end
-
     # Delegate ActiveRecord lifecycle checks to the wrapped record, so a Some
     # can stand in for its record during persistence.
     class Some

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -66,6 +66,15 @@ class BugTest < Minitest::Test
     assert book.isbn.none?
   end
 
+  # Option presence must beat ActiveSupport's Object#present?, where any
+  # non-nil object (including None) counts as present.
+  def test_option_presence_with_active_support_loaded
+    author = Author.create!(name: 'Cixin Liu')
+    assert author.bio.blank?
+    refute author.bio.present?
+    assert author.name.present?
+  end
+
   def test_optional_associations
     author = Author.create!(name: 'Cixin Liu')
     book = author.books.create!(title: 'The Dark Forest')


### PR DESCRIPTION
Fixes #17.

`None()` reported `present? == true` because `present?`/`blank?` were never defined on `Option` and fell through to `Object`, where any non-nil object is present. The `alias some? present?` lines in the Rails shim copied in the wrong direction and were shadowed by `Some`/`None`'s own `some?`/`none?`, so they were dead code in both directions.

## Changes

- Define `present?`/`blank?` on `Option::Any` as `some?`/`none?` (issue's suggested fix 1, hoisted to core: the gem's own `presence.rb` puts `present?` on `Object` even without ActiveSupport, so the bug existed outside Rails too).
- Remove the inert aliases from the Rails shim.
- Semantics decision from the issue: presence follows the discriminant, as in Rust — `Some(false).present?`, `Some(nil).present?`, and `Some("").present?` are all `true`. Stated in doctests and README.

## Tests

- Doctests on both new methods state the semantics and cover the `Some(false)`/`Some(nil)`/`Some("")` traps (red before the fix).
- `test/rails_test.rb` asserts Option presence beats ActiveSupport's `Object#present?` with Rails loaded — not expressible as a doctest, since doctests run without ActiveRecord.