### PR TITLE
Replace caller-depth guard with O(1) re-entrancy detection

### DIFF
--- a/lib/errgonomic.rb
+++ b/lib/errgonomic.rb
@@ -46,6 +46,11 @@ module Errgonomic
 
   class ResultRequiredError < Error; end
 
+  # Raised when a wrapped ActiveRecord attribute reader re-enters itself on
+  # the same record, catching runaway recursion at the first repeated frame
+  # instead of a SystemStackError thousands of frames later.
+  class RecursiveOptionalReadError < Error; end
+
   class NotComparableError < StandardError; end
 
   class SerializeError < TypeError; end

--- a/lib/errgonomic/rails.rb
+++ b/lib/errgonomic/rails.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'option'
+require_relative '../errgonomic'
 require_relative 'rails/active_record_optional'
 require_relative 'rails/active_record_delegate_optional'
 

--- a/lib/errgonomic/rails/active_record_optional.rb
+++ b/lib/errgonomic/rails/active_record_optional.rb
@@ -18,8 +18,19 @@ module Errgonomic
         @errgonomic_optionals.each do |name|
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def #{name}
-              raise "stack too deep" if caller.length > 1024
-              val = super
+              reads = Thread.current[:errgonomic_optional_reads] ||= {}
+              key = [object_id, :#{name}]
+              if reads[key]
+                raise Errgonomic::RecursiveOptionalReadError,
+                      "\#{self.class}##{name} re-entered itself; something beneath this reader reads it again"
+              end
+
+              reads[key] = true
+              begin
+                val = super
+              ensure
+                reads.delete(key)
+              end
               val.nil? ? Errgonomic::Option::None.new : Errgonomic::Option::Some.new(val)
             end
           RUBY

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -57,6 +57,21 @@ class Genre < ActiveRecord::Base
   delegate_optional :name, to: :parent, prefix: true, private: true
 end
 
+# A buggy layer that re-enters the attribute reader from beneath it: the
+# generated reader's super lands here, and the unqualified call restarts
+# dispatch at the top of the chain.
+module ReentrantBio
+  def bio
+    bio
+  end
+end
+
+class LoopyAuthor < ActiveRecord::Base
+  self.table_name = 'authors'
+  include ReentrantBio
+  include Errgonomic::Rails::ActiveRecordOptional
+end
+
 class BugTest < Minitest::Test
   def test_optional_attributes
     author = Author.create!(name: 'Cixin Liu')
@@ -88,10 +103,31 @@ class BugTest < Minitest::Test
     assert_equal author.name, book.author_name.unwrap!
   end
 
+  # Wrapped readers must work on a deep-but-legitimate stack; genuine runaway
+  # recursion is SystemStackError's job.
+  def test_optional_attributes_read_on_a_deep_stack
+    author = Author.create!(name: 'Cixin Liu', bio: 'writes sci-fi')
+    deeper(1100) { assert_equal 'writes sci-fi', author.bio.unwrap! }
+  end
+
+  def test_recursive_read_raises_a_named_error_at_first_reentry
+    author = LoopyAuthor.create!(name: 'Cixin Liu', bio: 'writes sci-fi')
+    error = assert_raises(Errgonomic::RecursiveOptionalReadError) { author.bio }
+    assert_match(/bio/, error.message)
+  end
+
   def test_private_delegate_optional
     fiction = Genre.create!(name: 'Fiction')
     scifi = Genre.create!(name: 'Sci-Fi', parent: fiction)
     assert_raises(NoMethodError) { scifi.parent_name }
     assert_equal 'Fiction', scifi.send(:parent_name).unwrap!
+  end
+
+  private
+
+  def deeper(frames, &block)
+    return block.call if frames.zero?
+
+    deeper(frames - 1, &block)
   end
 end


### PR DESCRIPTION
Fixes #16.

Every generated optional reader began with `raise "stack too deep" if caller.length > 1024`, which materializes the entire backtrace per attribute read. Measured on the gem's readers (100k reads, warm, Ruby 3.4):

| Arm | shallow stack | +100 frames |
|---|---|---|
| plain ActiveRecord reader | 0.10µs | 0.10µs |
| Option wrapping alone | ~0.4µs | ~0.4µs |
| `caller` guard (as shipped) | 3.9µs | 42µs |
| re-entrancy detector (this PR) | 0.49µs | 0.50µs |

This confirms the issue's numbers: the wrapping is cheap, the guard is the entire overhead, and it grows with stack depth.

## Why not just delete it (issue's option 1)

The guard existed for a reason: it once caught accidental infinite recursion through the generated readers that was otherwise hard to diagnose. That bug was fixed at some point, but nothing pins it down, so plain deletion would silently drop the diagnostic. This PR keeps the diagnostic and drops the cost — the issue's option 2:

- In-flight reads tracked in a thread-local keyed by `[object_id, attribute]`.
- Genuine re-entry raises `Errgonomic::RecursiveOptionalReadError` (selectively rescuable, unlike the old bare `RuntimeError`) at the **first** repeated frame, naming the class and attribute — instead of ~1024 frames in, or a `SystemStackError` thousands of frames later.
- A deep-but-legitimate stack no longer trips it: depth is irrelevant, only actual re-entry counts.

## Tests

- Reads succeed at 1100+ frames of legitimate stack depth (previously raised).
- A model with a layer beneath the reader that re-enters it raises `RecursiveOptionalReadError` naming the attribute — this is the regression net for the original recursion bug: any recurrence in any form of same-reader re-entry now fails fast and legibly.

Also fixes `errgonomic/rails` not requiring the gem root, which left the `Errgonomic` error classes undefined when required directly (as the tests do).