### PR TITLE
Debug-style inspect for Option and Result

### DIFF
--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -363,6 +363,12 @@ module Errgonomic
         raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Option'
       end
 
+      # pp uses its own object dump unless told otherwise; keep it consistent
+      # with inspect.
+      def pretty_print(pp)
+        pp.text(inspect)
+      end
+
       # filter
 
       # Return Some when either self or other are Some, otherwise return None
@@ -404,6 +410,18 @@ module Errgonomic
       def none?
         false
       end
+
+      # Render like Rust's Debug, delegating to the inner value's inspect so
+      # nesting stays unambiguous.
+      #
+      # @example
+      #   Some(5).inspect # => "Some(5)"
+      #   Some("x").inspect # => "Some(\"x\")"
+      #   Some(nil).inspect # => "Some(nil)"
+      #   Some(Some(1)).inspect # => "Some(Some(1))"
+      def inspect
+        "Some(#{value.inspect})"
+      end
     end
 
     # Represent the absence of a value.
@@ -414,6 +432,12 @@ module Errgonomic
 
       def none?
         true
+      end
+
+      # @example
+      #   None().inspect # => "None"
+      def inspect
+        'None'
       end
     end
   end

--- a/lib/errgonomic/result.rb
+++ b/lib/errgonomic/result.rb
@@ -283,6 +283,12 @@ module Errgonomic
         raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Result'
       end
 
+      # pp uses its own object dump unless told otherwise; keep it consistent
+      # with inspect.
+      def pretty_print(pp)
+        pp.text(inspect)
+      end
+
       # @example simple pattern match with variable capture of the value
       #   result = Errgonomic::Result::Ok.new(1)
       #   case result
@@ -326,6 +332,15 @@ module Errgonomic
       def err?
         false
       end
+
+      # Render like Rust's Debug, delegating to the inner value's inspect.
+      #
+      # @example
+      #   Ok(1).inspect # => "Ok(1)"
+      #   Ok("x").inspect # => "Ok(\"x\")"
+      def inspect
+        "Ok(#{value.inspect})"
+      end
     end
 
     # The Err variant.
@@ -357,6 +372,17 @@ module Errgonomic
       #   Err(:A).ok? # => false
       def ok?
         false
+      end
+
+      # Render like Rust's Debug; a value-less Err renders bare.
+      #
+      # @example
+      #   Err(:nope).inspect # => "Err(:nope)"
+      #   Err().inspect # => "Err()"
+      def inspect
+        return 'Err()' if value == Arbitrary
+
+        "Err(#{value.inspect})"
       end
     end
   end


### PR DESCRIPTION
Fixes #21.

`inspect` now renders like Rust's `Debug`: `Some(5)`, `None`, `Ok(1)`, `Err(:nope)`, `Err()`. Inner values render via their own `inspect`, so `Some(Some(1))` and `Some("x")` are unambiguous. `pretty_print` delegates to `inspect` (the issue's open question) since `pp` otherwise ignores `inspect` and prints its own object dump.

Result is included beyond the issue's scope: it had the identical problem and the same one-line answer.

Specified as doctests on `Some#inspect`, `None#inspect`, `Ok#inspect`, `Err#inspect`.