### PR TITLE
Option and Result satisfy the eql?/hash contract

### DIFF
--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -34,6 +34,34 @@ module Errgonomic
         value == other.value
       end
 
+      # Hash-based collections (Hash keys, Set, uniq, group_by) use eql? and
+      # hash, not ==. Follow the inner value's own eql? semantics, so Options
+      # behave as keys exactly like their inner values: Some(1) and Some(1.0)
+      # are distinct keys, just as 1 and 1.0 are.
+      #
+      # @example
+      #   Some(5).eql?(Some(5)) # => true
+      #   Some(1).eql?(Some(1.0)) # => false
+      #   None().eql?(None()) # => true
+      #   { Some(5) => 1 }[Some(5)] # => 1
+      #   [Some(1), Some(1), None(), None()].uniq # => [Some(1), None()]
+      def eql?(other)
+        return false if self.class != other.class
+        return true if none?
+
+        value.eql?(other.value)
+      end
+
+      # @example
+      #   Some(5).hash == Some(5).hash # => true
+      #   None().hash == None().hash # => true
+      #   Some(5).hash == None().hash # => false
+      def hash
+        return self.class.hash if none?
+
+        [self.class, value].hash
+      end
+
       # @example
       #   measurement = Errgonomic::Option::Some.new(1)
       #   case measurement

--- a/lib/errgonomic/result.rb
+++ b/lib/errgonomic/result.rb
@@ -28,6 +28,27 @@ module Errgonomic
         value == other.value
       end
 
+      # Hash-based collections (Hash keys, Set, uniq, group_by) use eql? and
+      # hash, not ==. Follow the inner value's own eql? semantics, so Results
+      # behave as keys exactly like their inner values.
+      #
+      # @example
+      #   Ok(5).eql?(Ok(5)) # => true
+      #   Ok(1).eql?(Ok(1.0)) # => false
+      #   Ok(1).eql?(Err(1)) # => false
+      #   { Ok(5) => 1 }[Ok(5)] # => 1
+      #   [Err(:a), Err(:a)].uniq # => [Err(:a)]
+      def eql?(other)
+        self.class == other.class && value.eql?(other.value)
+      end
+
+      # @example
+      #   Ok(5).hash == Ok(5).hash # => true
+      #   Ok(5).hash == Err(5).hash # => false
+      def hash
+        [self.class, value].hash
+      end
+
       # Indicate that this is some kind of result object. Contrast to
       # Object#result? which is false for all other types.
       #


### PR DESCRIPTION
Fixes #19.

Reproduced all of the issue's examples: `Some(5).eql?(Some(5))` was false, hash lookups missed, `uniq`/`group_by`/`Set` treated equal Options as distinct.

- `eql?` follows the inner value's own `eql?`, so `Some(1)` and `Some(1.0)` are distinct keys exactly as `1` and `1.0` are — the standard Ruby contract (`eql?` implies `hash` equality; `==` may be looser, as with Integer/Float).
- `hash` derives from `[class, value]`; all `None`s hash alike, and `Ok(5)`/`Err(5)` hash apart.
- Result had the identical defect, so it gets the same treatment.

Specified as doctests, including the `{ Some(5) => 1 }[Some(5)]` and `uniq` cases from the issue.