### PR TITLE
Option#filter and #flatten

### DIFF
--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -194,16 +194,6 @@ module Errgonomic
         value
       end
 
-      # # returns the inner value if present, else returns the default value
-      # # @example
-      # #   Some(1).unwrap_or(2) # => 1
-      # #   None().unwrap_or(2) # => 2
-      # def unwrap_or_default
-      #   self.class.respond_to?(:default) or raise
-      #   return self.class.default if none?
-      #   value
-      # end
-
       # returns the inner value if present, else returns the result of the
       # provided block
       # @example
@@ -423,7 +413,38 @@ module Errgonomic
         pp.text(inspect)
       end
 
-      # filter
+      # Return self if the predicate is truthy for the inner value, else None.
+      # None passes through.
+      #
+      # @example
+      #   Some(1).filter(&:odd?) # => Some(1)
+      #   Some(2).filter(&:odd?) # => None()
+      #   None().filter(&:odd?) # => None()
+      def filter(&block)
+        return self if none?
+
+        block.call(value) ? self : None()
+      end
+
+      # Remove one level of Option nesting. Pedantically raises when the inner
+      # value is not itself an Option, which in Rust would not have compiled.
+      #
+      # @example
+      #   Some(Some(1)).flatten # => Some(1)
+      #   Some(None()).flatten # => None()
+      #   None().flatten # => None()
+      #   Some(Some(Some(1))).flatten # => Some(Some(1))
+      #   Some(1).flatten # => raise Errgonomic::TypeMismatchError, "cannot flatten Integer; it is not an Option"
+      def flatten
+        return self if none?
+
+        unless value.is_a?(Errgonomic::Option::Any)
+          raise Errgonomic::TypeMismatchError,
+                "cannot flatten #{value.class}; it is not an Option"
+        end
+
+        value
+      end
 
       # Return Some when either self or other are Some, otherwise return None
       # when both are None or both are Some.
@@ -440,12 +461,8 @@ module Errgonomic
         None()
       end
 
-      # insert
-      # get_or_insert
-      # get_or_insert_with
-      # take
-      # take_if
-      # replace
+      # Rust's mutating combinators (insert, get_or_insert, take, replace)
+      # are deliberately omitted: an Option here is a value, not a slot.
     end
 
     # Represent a value


### PR DESCRIPTION
Fixes #23.

Adds `filter` (Some survives only if the predicate holds) and `flatten` (one level of nesting removed). Both sit in the intersection of Rust and Ruby idiom — Enumerable gives them Ruby precedent, and their semantics match `Option::filter` / `Option::flatten`. `flatten` raises `TypeMismatchError` when the inner value isn't an Option, a case Rust rejects at compile time, handled in the gem's pedantic style.

Declined, with rationale:

- `unzip` — Rust-idiomatic but has no Ruby analogue to anchor it (nothing in Enumerable unzips), so it falls outside the both-idioms sweet spot this gem targets. It also wasn't on the issue's priority list.
- `unwrap_or_default` — Ruby has no per-type default convention (`Integer` has no `.default`); `unwrap_or(0)` at the call site is clearer than any registry we could invent. The commented-out sketch in the source is removed.
- The mutating four (`insert`, `get_or_insert`, `take`, `replace`) — the issue itself suggests declining; an Option here is a return value, not a mutable slot. The stale TODO comment list is replaced with a one-line statement of that decision.

`xor` from the issue's table already landed in #13. Specified as doctests.