### PR TITLE
Accept Rust spellings of the predicates, with a nudge

### DIFF
--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -7,9 +7,19 @@ module Errgonomic
     class Any
       include Comparable
 
+      # Rust spellings we accept but do not advertise: they delegate to the
+      # Ruby-idiomatic predicate and nudge the caller there via stderr.
+      RUST_SPELLINGS = {
+        is_some: :some?,
+        is_none: :none?,
+        is_some_and: :some_and?,
+        is_none_or: :none_or?
+      }.freeze
+
       # An Option deliberately forwards nothing to its inner value, so a miss
       # here is almost always someone treating the container as its contents.
-      # Teach the route out instead of leaving a bare NoMethodError.
+      # Teach the route out instead of leaving a bare NoMethodError. Rust
+      # spellings of the predicates delegate, with a nudge on stderr.
       #
       # @example
       #   begin
@@ -18,7 +28,15 @@ module Errgonomic
       #     e.class
       #   end # => Errgonomic::UnwrappedAccessError
       #   Some(5).respond_to?(:+) # => false
-      def method_missing(name, *_args)
+      #   Some(1).is_some_and { |x| x > 0 } # => true
+      #   None().is_none # => true
+      #   Some(5).respond_to?(:is_some) # => true
+      def method_missing(name, *args, &block)
+        if (canonical = RUST_SPELLINGS[name])
+          warn "Errgonomic: `#{name}` is the Rust spelling; prefer `#{canonical}`. Delegating."
+          return public_send(canonical, *args, &block)
+        end
+
         raise Errgonomic::UnwrappedAccessError.new(<<~MSG, name)
           undefined method `#{name}' for #{inspect}, an Option, which does not forward methods to its inner value.
           Reach for a combinator instead:
@@ -31,7 +49,7 @@ module Errgonomic
       end
 
       def respond_to_missing?(name, include_private = false)
-        super
+        RUST_SPELLINGS.key?(name) || super
       end
 
       # An Option equals another Option of the same class with an equal inner

--- a/lib/errgonomic/result.rb
+++ b/lib/errgonomic/result.rb
@@ -33,9 +33,19 @@ module Errgonomic
         value <=> other.value
       end
 
+      # Rust spellings we accept but do not advertise: they delegate to the
+      # Ruby-idiomatic predicate and nudge the caller there via stderr.
+      RUST_SPELLINGS = {
+        is_ok: :ok?,
+        is_err: :err?,
+        is_ok_and: :ok_and?,
+        is_err_and: :err_and?
+      }.freeze
+
       # A Result deliberately forwards nothing to its inner value, so a miss
       # here is almost always someone treating the container as its contents.
-      # Teach the route out instead of leaving a bare NoMethodError.
+      # Teach the route out instead of leaving a bare NoMethodError. Rust
+      # spellings of the predicates delegate, with a nudge on stderr.
       #
       # @example
       #   begin
@@ -44,7 +54,15 @@ module Errgonomic
       #     e.class
       #   end # => Errgonomic::UnwrappedAccessError
       #   Ok(5).respond_to?(:+) # => false
-      def method_missing(name, *_args)
+      #   Ok(1).is_ok_and(&:odd?) # => true
+      #   Err(:a).is_err # => true
+      #   Ok(1).respond_to?(:is_ok) # => true
+      def method_missing(name, *args, &block)
+        if (canonical = RUST_SPELLINGS[name])
+          warn "Errgonomic: `#{name}` is the Rust spelling; prefer `#{canonical}`. Delegating."
+          return public_send(canonical, *args, &block)
+        end
+
         raise Errgonomic::UnwrappedAccessError.new(<<~MSG, name)
           undefined method `#{name}' for #{inspect}, a Result, which does not forward methods to its inner value.
           Reach for a combinator instead:
@@ -56,7 +74,7 @@ module Errgonomic
       end
 
       def respond_to_missing?(name, include_private = false)
-        super
+        RUST_SPELLINGS.key?(name) || super
       end
 
       # Equality comparison for Result objects is based on value not reference.


### PR DESCRIPTION
Fixes #24. Stacked on #33 (base: `feat/teaching-no-method-error`); GitHub will retarget to `main` when #33 merges.

Middle path between the issue's alias suggestion and a flat won't-fix: the Rust spellings (`is_some`, `is_none`, `is_some_and`, `is_none_or`, plus `is_ok`/`is_err`/`is_ok_and`/`is_err_and` on Result) work — they delegate through `method_missing` to the canonical predicate — but each call prints a one-line stderr nudge naming the preferred spelling. So a Rust porter's guess succeeds instead of dead-ending, while the Ruby `?` predicates stay the only advertised API (no real methods added, docs unchanged).

`respond_to?` answers true for the mapped names, since lying about a call that works would misroute duck-type checks.

Specified as doctests (delegation results; the stderr nudge doesn't affect doctest output).