### PR TITLE
Document Option equality semantics; resolve the None == nil TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ An unhandled Option refuses to leak into your output: `to_s` and `to_json` raise
 
 Presence follows the discriminant, as in Rust: `Some` is `present?` and `None` is `blank?`, regardless of the wrapped value. So `Some(false).present?` and `Some(nil).present?` are both `true`. If you care about the inner value's own presence, unwrap it first.
 
+Equality is between Options only: `Some(5) == Some(5)`, but `Some(5) == 5` and `None() == nil` are `false`. That is quiet, never an error, matching how every Ruby object compares across types. Rust rejects `Some(5) == 5` at compile time; Ruby cannot, so guard the idiom in review and tests: compare against a wrapped value (`opt == Some(5)`) or test the inner value (`opt.some_and? { |v| v == 5 }`).
+
 ### Result
 
 `Ok(value)` and `Err(error)` express an operation that may fail, again with the Rust combinators:

--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -9,16 +9,18 @@ module Errgonomic
       #   raise 'do it right noob'
       # end
 
-      # An option of the same type with an equal inner value is equal.
+      # An Option equals another Option of the same class with an equal inner
+      # value. Anything else, including nil and the raw inner value, is not
+      # equal: quietly false, never an error. Rust rejects Some(5) == 5 at
+      # compile time; Ruby cannot, and raising here would break the many
+      # places Ruby compares heterogeneous operands (Array#include?,
+      # assertion diffs, dirty tracking). Compare Options (opt == Some(5)) or
+      # test the inner value (opt.some_and? { |v| v == 5 }) instead.
       #
-      # Because we're going to monkey patch this into other libraries Rails, we
-      # allow some "pass through" functionality into the inner value of a Some,
-      # such as comparability here.
-      #
-      # TODO: does None == null?
-      #
-      # strict:
-      #   Some(1) == 1 # => raise Errgonomic::NotComparableError, "Cannot compare Errgonomic::Option::Some with Integer"
+      # None() == nil is likewise false: None is a value that represents
+      # absence, not an absence Ruby can see. (The Rails integration
+      # separately makes None#nil? answer true, as an ActiveRecord
+      # compromise; equality does not follow it.)
       #
       # @example
       #   Some(1) == Some(1) # => true


### PR DESCRIPTION
Closes #20 as won't-fix-the-behavior, with the docs the issue asked for as the fallback.

The issue wants `Some(5) == 5` to raise `TypeMismatchError`. Declining the raise: `==` is called pervasively with heterogeneous operands in Ruby — `[Some(1), "x"].include?(Some(1))` calls `Some(1) == "x"`, `assert_equal 1, opt` diffs across types, ActiveRecord dirty tracking compares old/new attribute values — and every other Ruby object answers cross-type `==` with `false`. A raise converts silent-wrong into loud-wrong at innocent call sites, which is the worse trade. The discoverability gap is instead covered by #33's teaching `UnwrappedAccessError` and #29's readable `inspect`, which make a mistyped comparison visible the moment anything touches the value.

What this PR does:

- Resolves the `TODO: does None == nil?` — the answer is no, `None() == nil` stays `false`. `None` is a value representing absence, not an absence Ruby can see. The Rails shim's `None#nil? == true` is documented as an ActiveRecord compromise that equality deliberately does not follow (#25 covers the compromise set).
- Rewrites the `==` doc comment with the rationale and the idioms (`opt == Some(5)`, `opt.some_and? { |v| v == 5 }`), removing the stale `strict:` sketch.
- Adds the equality paragraph to the README's Option section.

No behavior change; the existing `==` doctests already pin all six cases.