### PR TITLE
Document the ActiveRecord compromise set as named and closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ When `Rails::Railtie` is defined, Errgonomic installs a Railtie with two opt-in 
 
 `Object#to_option` is also available in Rails to lift any value into an Option (`nil.to_option # => None()`).
 
+#### ActiveRecord compromises
+
+ActiveRecord assumes things about accessors that a strict Rust Option cannot satisfy, so the integration carries four deliberate compromises. Everywhere else, treat a departure from Rust's `Option` semantics as a bug; these four are intended:
+
+1. `None#nil?` answers `true`, so ActiveRecord internals and ordinary `.nil?` checks treat an absent value as absent. Equality does not follow suit: `None() == nil` is still `false`.
+2. `Some` delegates `persisted?`, `marked_for_destruction?`, and `touch_later` to its record, so a `Some` can stand in for its record during persistence.
+3. Quoting is patched so an `Option` passed into `where`/`quote` is unwrapped at the SQL boundary.
+4. `SomeValidator` provides a presence-style validation for Option attributes.
+
+The set is closed. If a future integration appears to need a fifth compromise, that is a signal ActiveRecord is pushing back somewhere unmapped, and it warrants a design discussion rather than a quiet patch.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment. The repository is a self-contained Nix flake; with direnv, `direnv allow` puts the right toolchain on your path.

--- a/lib/errgonomic/rails/active_record_optional.rb
+++ b/lib/errgonomic/rails/active_record_optional.rb
@@ -4,6 +4,21 @@ module Errgonomic
   module Rails
     # Concern to make ActiveRecord optional attributes and associations return an Option.
     #
+    # Four pragmatic compromises below satisfy ActiveRecord's assumptions
+    # about how accessors behave. They are deliberate exceptions to "Option
+    # behaves like Rust's Option", and the set is closed: a fifth would be a
+    # signal that ActiveRecord is pushing back somewhere unmapped, deserving
+    # a design discussion rather than a quiet patch.
+    #
+    # 1. None#nil? answers true, so AR internals and ordinary nil checks
+    #    treat an absent value as absent. Equality does not follow suit:
+    #    None() == nil stays false.
+    # 2. Some delegates persisted?, marked_for_destruction?, and touch_later
+    #    to its record, so a Some can stand in for it during persistence.
+    # 3. Two quoting prepends unwrap Options at the SQL boundary, so an
+    #    Option can be passed to where/quote.
+    # 4. SomeValidator provides a presence-style validation for Option
+    #    attributes.
     module ActiveRecordOptional
       extend ActiveSupport::Concern
 


### PR DESCRIPTION
Closes #25.

Docs only, as the issue asks: the four compromises are named as a set in the `ActiveRecordOptional` concern header and in a new README subsection under Rails integration, stated as deliberate exceptions to "Option behaves like Rust's Option" (everywhere else, a departure is a bug), with the set declared closed.

On the issue's note about revisiting `None#nil?`: not bundled here. It's load-bearing in an unmapped way (the same property that made the original reader-recursion bug hard to pin down in #16 suggests the AR interaction surface isn't fully understood), and narrowing it deserves its own issue with an audit of which AR code paths actually depend on it. The equality boundary is already pinned: `None() == nil` stays `false` (#35).