### PR TITLE
README: unwrap! guidance and ActiveRecordOptional scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ end
 
 An unhandled Option refuses to leak into your output: `to_s` and `to_json` raise `Errgonomic::SerializeError`, so you handle the inner value deliberately rather than shipping `#<Errgonomic::Option::Some...>` to a user.
 
+`unwrap!` and `expect!` are for tests and consoles, not application code: they raise on `None`, which is exactly the ambiguous failure the type exists to prevent. Application code should always have a combinator or pattern match that handles the `None` branch explicitly; if none fits, that is a gap worth an issue rather than a reason to unwrap.
+
 Presence follows the discriminant, as in Rust: `Some` is `present?` and `None` is `blank?`, regardless of the wrapped value. So `Some(false).present?` and `Some(nil).present?` are both `true`. If you care about the inner value's own presence, unwrap it first.
 
 ### Result
@@ -158,7 +160,7 @@ end
 
 When `Rails::Railtie` is defined, Errgonomic installs a Railtie with two opt-in integrations for ActiveRecord:
 
-- `include Errgonomic::Rails::ActiveRecordOptional` in a model makes its nullable attributes and `optional: true` associations return `Some(value)` or `None()` instead of a value-or-nil.
+- `include Errgonomic::Rails::ActiveRecordOptional` in a model makes its nullable attributes and `optional: true` associations return `Some(value)` or `None()` instead of a value-or-nil. This is all-or-nothing per model: every nullable column and optional association is wrapped, with no per-attribute opt-in.
 - `delegate_optional :name, to: :association` (available on all models) delegates through an optional association, returning an Option instead of raising on nil.
 
 `Object#to_option` is also available in Rails to lift any value into an Option (`nil.to_option # => None()`).


### PR DESCRIPTION
Closes #26.

Most of the issue predates the README refresh that landed in #15: the scaffold TODOs are gone, and Option, Result, pattern matching, pedantic checks, and the Rails integrations are documented. The departures-from-Rust ask is covered by the presence paragraph (#27), the equality paragraph (#35), and the named ActiveRecord compromise set (#36).

This PR adds the two asks still missing:

- An explicit statement that `unwrap!`/`expect!` are for tests and consoles, not application code, with the reasoning (they reintroduce the ambiguous failure the type exists to prevent). The same guidance ships in #33's error message.
- The all-or-nothing nature of `ActiveRecordOptional`: every nullable column and `optional: true` association is wrapped, no per-attribute opt-in.