### PR TITLE
Optional collections: OptionalHash, OptionalArray, and additive lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,33 @@ end
 
 Like Options, unwrapped Results refuse `to_s` and `to_json`. And `Object#result?` / `Object#assert_result!` help enforce at runtime that a value is a Result.
 
+### Optional collections
+
+Hash and Array gain two additive lookups each, and nothing else changes about them. `fetch_option` follows presence the way Rust's `HashMap#get` and slice `get` do: a present key or index holding `nil` is `Some(nil)`, and only a missing one is `None()`.
+
+```ruby
+h = { color: :blue, shade: nil }
+h.fetch_option(:color)  # => Some(:blue)
+h.fetch_option(:shade)  # => Some(nil)
+h.fetch_option(:smell)  # => None()
+
+[:a, nil].fetch_option(1)  # => Some(nil)
+[:a, nil].fetch_option(2)  # => None()
+```
+
+`into_optional` wraps the collection in `Errgonomic::OptionalHash` / `Errgonomic::OptionalArray`, a view whose lookups all return Options. The wrappers are deliberately small — `[]`, `[]=`, `dig`, presence checks, and (for arrays) `first`/`last` — and are composed around the plain collection rather than subclassing it, because a subclass sheds its custom semantics every time `select` or `transform_values` returns a plain Hash. `to_h` / `to_a` hand back a detached copy.
+
+```ruby
+h = { person: { name: 'Ada', middle_name: nil } }.into_optional
+h.dig(:person, :name)         # => Some("Ada")
+h.dig(:person, :middle_name)  # => Some(nil)   (present, holding nil)
+h.dig(:person, :nickname)     # => None()      (absent)
+
+[].into_optional.first        # => None()
+```
+
+`dig` checks presence at every step, so an absent path and a present `nil` stay distinguishable, which core `dig` conflates. Digging into a non-collection raises `Errgonomic::TypeMismatchError` rather than answering `None()`, in the gem's pedantic style.
+
 ### Pedantic runtime checks
 
 Combinators that accept a block (`and_then`, `or_else`, ...) check at runtime that the block returned an Option or Result, raising `Errgonomic::ArgumentError` otherwise. That beats an ambiguous `undefined method` error somewhere downstream. If you would rather have the ambiguous downstream errors, you can opt out — but not quietly:

--- a/lib/errgonomic.rb
+++ b/lib/errgonomic.rb
@@ -12,6 +12,10 @@ require_relative 'errgonomic/type'
 require_relative 'errgonomic/option'
 require_relative 'errgonomic/result'
 
+# Option-returning lookups for the collections.
+require_relative 'errgonomic/core_ext/hash'
+require_relative 'errgonomic/core_ext/array'
+
 # Rails fu
 require_relative 'errgonomic/rails' if defined?(Rails::Railtie)
 

--- a/lib/errgonomic/core_ext/array.rb
+++ b/lib/errgonomic/core_ext/array.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative '../option'
+require_relative '../optional_array'
+
+# Two additive lookups; no existing Array behavior changes, for the same
+# reasons given in core_ext/hash.rb.
+class Array
+  # Retrieve the element at an integer index, wrapped in an Option,
+  # following element presence as Rust's slice get does: an element holding
+  # nil is Some(nil); only an out-of-bounds index is None.
+  #
+  # @example
+  #   a = [:a, nil]
+  #   a.fetch_option(0) # => Some(:a)
+  #   a.fetch_option(1) # => Some(nil)
+  #   a.fetch_option(2) # => None()
+  def fetch_option(index)
+    unless index.is_a?(::Integer)
+      raise Errgonomic::TypeMismatchError,
+            "index must be an Integer, got #{index.class}"
+    end
+    return None() unless (-length...length).cover?(index)
+
+    Some(self[index])
+  end
+
+  # Wrap this array in an Errgonomic::OptionalArray view. The wrapper reads
+  # and writes this same array; use its to_a for a detached copy.
+  #
+  # @example
+  #   a = [:a].into_optional
+  #   a[0] # => Some(:a)
+  #   a[1] # => None()
+  def into_optional
+    Errgonomic::OptionalArray.new(self)
+  end
+end

--- a/lib/errgonomic/core_ext/hash.rb
+++ b/lib/errgonomic/core_ext/hash.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative '../option'
+require_relative '../optional_hash'
+
+# Two additive lookups; no existing Hash behavior changes. This is as deep as
+# the gem reaches into Hash: the wider Ruby ecosystem leans on Hash semantics
+# too heavily to patch them, so richer behavior lives in
+# Errgonomic::OptionalHash instead.
+class Hash
+  # Retrieve the value for a key, wrapped in an Option, following key
+  # presence as Rust's HashMap#get does: a present key with a nil value is
+  # Some(nil); only a missing key is None.
+  #
+  # @example
+  #   h = { color: :blue, shade: nil }
+  #   h.fetch_option(:color) # => Some(:blue)
+  #   h.fetch_option(:shade) # => Some(nil)
+  #   h.fetch_option(:smell) # => None()
+  def fetch_option(key)
+    return None() unless key?(key)
+
+    Some(self[key])
+  end
+
+  # Wrap this hash in an Errgonomic::OptionalHash view. The wrapper reads and
+  # writes this same hash; use its to_h for a detached copy.
+  #
+  # @example
+  #   h = { color: :blue }.into_optional
+  #   h[:color] # => Some(:blue)
+  #   h[:smell] # => None()
+  def into_optional
+    Errgonomic::OptionalHash.new(self)
+  end
+end

--- a/lib/errgonomic/optional_array.rb
+++ b/lib/errgonomic/optional_array.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require_relative 'option'
+require_relative 'optional_dig'
+
+module Errgonomic
+  # A companion to Array whose lookups return Options, composed around a
+  # plain Array for the same reasons OptionalHash composes around a Hash.
+  # Lookups follow element presence: an element holding nil is Some(nil),
+  # and only an out-of-bounds index is None, as with Rust's slice get.
+  class OptionalArray
+    include OptionalDig
+
+    def initialize(array = [])
+      unless array.is_a?(::Array)
+        raise Errgonomic::TypeMismatchError,
+              "OptionalArray wraps an Array, got #{array.class}"
+      end
+
+      @array = array
+    end
+
+    # Retrieve the element at an integer index, wrapped in an Option.
+    # Negative indexes count from the end, as usual. A non-integer index
+    # raises, pedantically: the silent nil of Array#[] with a bad argument is
+    # the ambiguity this class exists to remove.
+    #
+    # @example
+    #   a = [:a, nil].into_optional
+    #   a[0] # => Some(:a)
+    #   a[1] # => Some(nil)
+    #   a[2] # => None()
+    #   a[-1] # => Some(nil)
+    #   a[:nope] # => raise Errgonomic::TypeMismatchError, "index must be an Integer, got Symbol"
+    def [](index)
+      unless index.is_a?(::Integer)
+        raise Errgonomic::TypeMismatchError,
+              "index must be an Integer, got #{index.class}"
+      end
+      return None() unless (-@array.length...@array.length).cover?(index)
+
+      Some(@array[index])
+    end
+
+    # Write through to the underlying array.
+    #
+    # @example
+    #   a = [].into_optional
+    #   a[0] = :a
+    #   a[0] # => Some(:a)
+    def []=(index, value)
+      @array[index] = value
+    end
+
+    # Like Array#dig, but every step checks presence, so an absent path
+    # (None) stays distinct from a present nil (Some(nil)).
+    #
+    # @example
+    #   a = [{ name: 'Ada' }].into_optional
+    #   a.dig(0, :name) # => Some("Ada")
+    #   a.dig(0, :nickname) # => None()
+    #   a.dig(1, :name) # => None()
+    def dig(index, *rest)
+      optional_dig(@array, [index, *rest])
+    end
+
+    # The first element as an Option, as with Rust's slice first.
+    #
+    # @example
+    #   [1, 2].into_optional.first # => Some(1)
+    #   [nil].into_optional.first # => Some(nil)
+    #   [].into_optional.first # => None()
+    def first
+      return None() if @array.empty?
+
+      Some(@array.first)
+    end
+
+    # The last element as an Option, as with Rust's slice last.
+    #
+    # @example
+    #   [1, 2].into_optional.last # => Some(2)
+    #   [].into_optional.last # => None()
+    def last
+      return None() if @array.empty?
+
+      Some(@array.last)
+    end
+
+    # @example
+    #   [].into_optional.empty? # => true
+    #   [1].into_optional.empty? # => false
+    def empty?
+      @array.empty?
+    end
+
+    # @example
+    #   [1, 2].into_optional.size # => 2
+    def size
+      @array.size
+    end
+
+    # The escape hatch back to a plain Array: a shallow copy, so array-shaped
+    # code cannot mutate the wrapped state behind the Option semantics.
+    #
+    # @example
+    #   [1].into_optional.to_a # => [1]
+    def to_a
+      @array.dup
+    end
+
+    # Equal to another OptionalArray wrapping an equal array; never equal to
+    # a plain Array, mirroring how Some(x) is never equal to x.
+    #
+    # @example
+    #   [1].into_optional == [1].into_optional # => true
+    #   [1].into_optional == [2].into_optional # => false
+    #   [1].into_optional == [1] # => false
+    def ==(other)
+      other.is_a?(OptionalArray) && inner == other.inner
+    end
+
+    # @example
+    #   [1].into_optional.eql?([1].into_optional) # => true
+    #   { [1].into_optional => :hit }[[1].into_optional] # => :hit
+    def eql?(other)
+      other.is_a?(OptionalArray) && inner.eql?(other.inner)
+    end
+
+    def hash
+      [self.class, inner].hash
+    end
+
+    # @example
+    #   [1].into_optional.inspect # => "OptionalArray([1])"
+    def inspect
+      "OptionalArray(#{@array.inspect})"
+    end
+
+    protected
+
+    def inner
+      @array
+    end
+  end
+end

--- a/lib/errgonomic/optional_dig.rb
+++ b/lib/errgonomic/optional_dig.rb
@@ -6,17 +6,18 @@ module Errgonomic
   # The presence-checking walk behind OptionalHash#dig and OptionalArray#dig:
   # every step checks key or bounds presence, so an absent path (None) stays
   # distinct from a present nil (Some(nil)), which the core dig methods
-  # conflate. Digging into a non-collection raises, pedantically, where core
-  # dig would raise TypeError.
+  # conflate. A nested wrapper handles the rest of the walk itself, by
+  # recursion. Digging into a non-collection raises, pedantically, where
+  # core dig would raise TypeError.
   module OptionalDig
     private
 
     def optional_dig(start, keys)
       current = start
-      keys.each do |key|
-        current = current.to_h if current.is_a?(OptionalHash)
-        current = current.to_a if current.is_a?(OptionalArray)
+      keys.each_with_index do |key, idx|
         case current
+        when OptionalHash, OptionalArray
+          return current.dig(key, *keys[(idx + 1)..])
         when ::Hash
           return None() unless current.key?(key)
         when ::Array

--- a/lib/errgonomic/optional_dig.rb
+++ b/lib/errgonomic/optional_dig.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'option'
+
+module Errgonomic
+  # The presence-checking walk behind OptionalHash#dig and OptionalArray#dig:
+  # every step checks key or bounds presence, so an absent path (None) stays
+  # distinct from a present nil (Some(nil)), which the core dig methods
+  # conflate. Digging into a non-collection raises, pedantically, where core
+  # dig would raise TypeError.
+  module OptionalDig
+    private
+
+    def optional_dig(start, keys)
+      current = start
+      keys.each do |key|
+        current = current.to_h if current.is_a?(OptionalHash)
+        current = current.to_a if current.is_a?(OptionalArray)
+        case current
+        when ::Hash
+          return None() unless current.key?(key)
+        when ::Array
+          return None() unless key.is_a?(Integer) && (-current.length...current.length).cover?(key)
+        else
+          raise Errgonomic::TypeMismatchError, "cannot dig into #{current.class}"
+        end
+        current = current[key]
+      end
+      Some(current)
+    end
+  end
+end

--- a/lib/errgonomic/optional_hash.rb
+++ b/lib/errgonomic/optional_hash.rb
@@ -67,6 +67,11 @@ module Errgonomic
     #   h.dig(:people, 0, :name) # => Some("Ada")
     #   h.dig(:people, 1, :name) # => None()
     #
+    # @example a nested wrapper walks the rest of the path itself
+    #   h = { person: { name: 'Ada' }.into_optional }.into_optional
+    #   h.dig(:person, :name) # => Some("Ada")
+    #   h.dig(:person, :nickname) # => None()
+    #
     # @example digging into a non-collection is an error, not a None
     #   h = { name: 'Ada' }.into_optional
     #   h.dig(:name, :length) # => raise Errgonomic::TypeMismatchError, "cannot dig into String"

--- a/lib/errgonomic/optional_hash.rb
+++ b/lib/errgonomic/optional_hash.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require_relative 'option'
+require_relative 'optional_dig'
+
+module Errgonomic
+  # A companion to Hash whose lookups return Options, composed around a plain
+  # Hash rather than subclassing it. Subclassing cannot keep Option semantics:
+  # since Ruby 3, most Hash methods return plain Hash instances, so wrapped
+  # behavior silently drops off in pipelines. Composition with a small, closed
+  # API keeps the semantics honest; reach the plain Hash back with to_h.
+  #
+  # Lookups follow key presence, not value truthiness, so a key holding nil is
+  # Some(nil). This matches Option presence semantics: the discriminant tells
+  # you whether the key was there, and the inner value is yours to judge.
+  class OptionalHash
+    include OptionalDig
+
+    def initialize(hash = {})
+      unless hash.is_a?(::Hash)
+        raise Errgonomic::TypeMismatchError,
+              "OptionalHash wraps a Hash, got #{hash.class}"
+      end
+
+      @hash = hash
+    end
+
+    # Retrieve the value for a key, wrapped in an Option. A present key with
+    # a nil value is Some(nil); only a missing key is None.
+    #
+    # @example
+    #   h = { color: :blue, shade: nil }.into_optional
+    #   h[:color] # => Some(:blue)
+    #   h[:shade] # => Some(nil)
+    #   h[:smell] # => None()
+    def [](key)
+      return None() unless @hash.key?(key)
+
+      Some(@hash[key])
+    end
+
+    # Write through to the underlying hash.
+    #
+    # @example
+    #   h = {}.into_optional
+    #   h[:color] = :blue
+    #   h[:color] # => Some(:blue)
+    def []=(key, value)
+      @hash[key] = value
+    end
+
+    # Like Hash#dig, but every step checks presence, so the result
+    # distinguishes an absent path (None) from a present nil (Some(nil)),
+    # which Hash#dig conflates. Walks nested Hashes, Arrays, and
+    # OptionalHashes; digging into anything else raises, pedantically, where
+    # Hash#dig would raise TypeError.
+    #
+    # @example
+    #   h = { person: { name: 'Ada', middle_name: nil } }.into_optional
+    #   h.dig(:person, :name) # => Some("Ada")
+    #   h.dig(:person, :middle_name) # => Some(nil)
+    #   h.dig(:person, :nickname) # => None()
+    #   h.dig(:company, :name) # => None()
+    #
+    # @example arrays participate, with bounds checked
+    #   h = { people: [{ name: 'Ada' }] }.into_optional
+    #   h.dig(:people, 0, :name) # => Some("Ada")
+    #   h.dig(:people, 1, :name) # => None()
+    #
+    # @example digging into a non-collection is an error, not a None
+    #   h = { name: 'Ada' }.into_optional
+    #   h.dig(:name, :length) # => raise Errgonomic::TypeMismatchError, "cannot dig into String"
+    def dig(key, *rest)
+      optional_dig(@hash, [key, *rest])
+    end
+
+    # @example
+    #   h = { shade: nil }.into_optional
+    #   h.key?(:shade) # => true
+    #   h.key?(:color) # => false
+    def key?(key)
+      @hash.key?(key)
+    end
+
+    # @example
+    #   {}.into_optional.empty? # => true
+    #   { a: 1 }.into_optional.empty? # => false
+    def empty?
+      @hash.empty?
+    end
+
+    # @example
+    #   { a: 1 }.into_optional.size # => 1
+    def size
+      @hash.size
+    end
+
+    # The escape hatch back to a plain Hash: a shallow copy, so hash-shaped
+    # code cannot mutate the wrapped state behind the Option semantics.
+    #
+    # @example
+    #   { a: 1 }.into_optional.to_h # => { a: 1 }
+    def to_h
+      @hash.dup
+    end
+
+    # Equal to another OptionalHash wrapping an equal hash; never equal to a
+    # plain Hash, mirroring how Some(x) is never equal to x.
+    #
+    # @example
+    #   { a: 1 }.into_optional == { a: 1 }.into_optional # => true
+    #   { a: 1 }.into_optional == { a: 2 }.into_optional # => false
+    #   { a: 1 }.into_optional == { a: 1 } # => false
+    def ==(other)
+      other.is_a?(OptionalHash) && inner == other.inner
+    end
+
+    # @example
+    #   { a: 1 }.into_optional.eql?({ a: 1 }.into_optional) # => true
+    #   h = { a: 1 }.into_optional
+    #   { h => :hit }[{ a: 1 }.into_optional] # => :hit
+    def eql?(other)
+      other.is_a?(OptionalHash) && inner.eql?(other.inner)
+    end
+
+    def hash
+      [self.class, inner].hash
+    end
+
+    # @example
+    #   {}.into_optional.inspect # => "OptionalHash({})"
+    def inspect
+      "OptionalHash(#{@hash.inspect})"
+    end
+
+    protected
+
+    def inner
+      @hash
+    end
+  end
+end


### PR DESCRIPTION
Supersedes #6, keeping its idea (Option-returning hash lookups, with the explicit-key-check semantics from its second commit) and replacing the vehicle. The both-and shape agreed in review:

## Additive core extensions, nothing else touched

`Hash#fetch_option` / `Array#fetch_option` return an Option following presence, exactly as Rust's `HashMap::get` and slice `get` do: present-but-nil is `Some(nil)`, only absent is `None()`. `Hash#into_optional` / `Array#into_optional` wrap the collection in the view classes (precedent: `Hash#with_indifferent_access` is itself an additive core patch). No existing Hash/Array behavior changes; verified the names collide with nothing in ActiveSupport 8.1 (`Hash` has only `to_options`/`extractable_options?` in that namespace).

## Composition, not subclassing

`Errgonomic::OptionalHash` and `Errgonomic::OptionalArray` wrap a plain collection with a deliberately small, closed API: `[]`, `[]=`, `dig`, `key?`/bounds, `empty?`, `size`, `to_h`/`to_a` (detached copies), equality satisfying the `eql?`/`hash` contract (#30), readable `inspect` (#21), and `first`/`last` as Options on the array (Rust's slice `first`/`last`).

Why not `< Hash`, verified against Ruby 3.4 while reviewing #6:

- `select`/`transform_values` on a Hash subclass return plain `Hash`, so Option semantics silently shed in any pipeline. Doing this properly is the HWIA approach: override the entire ~40-method surface.
- `Hash#dig` bypasses an overridden `[]` at the C level, so #6's `dig` never saw the wrapped values its unwrap-loop expected.
- #6's `[]` and `dig` disagreed about stored nil (`Some(nil)` vs `None()`). Here one shared walk (`OptionalDig`) gives both classes the same semantics, and `dig` distinguishes absent path (`None`) from present nil (`Some(nil)`) — the one thing core `dig` cannot express.

Digging into a non-collection raises `TypeMismatchError` in the gem's pedantic style, where core `dig` raises `TypeError`.

Specified as doctests (23 new); README gains an Optional collections section.