### PR TITLE
Booleans lift into Option and Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ h.dig(:person, :nickname)     # => None()      (absent)
 
 `dig` checks presence at every step, so an absent path and a present `nil` stay distinguishable, which core `dig` conflates. Digging into a non-collection raises `Errgonomic::TypeMismatchError` rather than answering `None()`, in the gem's pedantic style.
 
+### Booleans
+
+Booleans lift into the containers, following Rust's `bool`: `then_some`, and `ok_or`/`ok_or_else` from nightly. Rust splits the lazy form into `then`, but that name is core Ruby (`Kernel#then`), which Errgonomic will not redefine; `then_some` takes either a value or a block instead. Rust's `ok_or` returns `Result<(), E>`; Ruby has no unit type, so `Ok` carries `true`.
+
+```ruby
+admin.then_some(:badge)       # => Some(:badge) when true, None() when false
+admin.then_some { badge! }    # lazy variant
+valid.ok_or("invalid input")  # => Ok(true) / Err("invalid input")
+```
+
 ### Pedantic runtime checks
 
 Combinators that accept a block (`and_then`, `or_else`, ...) check at runtime that the block returned an Option or Result, raising `Errgonomic::ArgumentError` otherwise. That beats an ambiguous `undefined method` error somewhere downstream. If you would rather have the ambiguous downstream errors, you can opt out — but not quietly:

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,9 @@ end
 require 'yard/doctest/rake'
 YARD::Doctest::RakeTask.new do |task|
   task.doctest_opts = %w[-v]
-  task.pattern = 'lib/**/*.rb'
+  # Expand here: the pattern reaches yard through a shell whose ** means *,
+  # which silently dropped every doctest under lib/errgonomic/*/.
+  task.pattern = FileList['lib/**/*.rb'].join(' ')
 end
 
 task default: %i[test yard:doctest]

--- a/lib/errgonomic.rb
+++ b/lib/errgonomic.rb
@@ -16,6 +16,9 @@ require_relative 'errgonomic/result'
 require_relative 'errgonomic/core_ext/hash'
 require_relative 'errgonomic/core_ext/array'
 
+# Lift booleans into Option and Result.
+require_relative 'errgonomic/core_ext/bool'
+
 # Rails fu
 require_relative 'errgonomic/rails' if defined?(Rails::Railtie)
 

--- a/lib/errgonomic/core_ext/bool.rb
+++ b/lib/errgonomic/core_ext/bool.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative '../option'
+require_relative '../result'
+
+# Lift booleans into Option and Result, following Rust's bool: then_some,
+# and ok_or/ok_or_else from nightly. Rust splits the lazy form into `then`,
+# but that name is core Ruby (Kernel#then), so then_some takes either a
+# value or a block. Rust's ok_or returns Result<(), E>; Ruby has no unit
+# type, so Ok carries true.
+class TrueClass
+  # @example
+  #   true.then_some(:hello) # => Some(:hello)
+  #   true.then_some { :hello } # => Some(:hello)
+  #   true.then_some(nil) # => Some(nil)
+  #   true.then_some # => raise Errgonomic::ArgumentError, "then_some takes either a value or a block"
+  def then_some(*args, &block)
+    if args.length == 1 && !block
+      Some(args[0])
+    elsif args.empty? && block
+      Some(block.call)
+    else
+      raise Errgonomic::ArgumentError, 'then_some takes either a value or a block'
+    end
+  end
+
+  # @example
+  #   true.ok_or(:ohno) # => Ok(true)
+  def ok_or(_err)
+    Ok(true)
+  end
+
+  # @example
+  #   true.ok_or_else { :ohno } # => Ok(true)
+  def ok_or_else
+    Ok(true)
+  end
+end
+
+# The false halves of the conversions above.
+class FalseClass
+  # The block is never called; arguments are validated all the same, so a
+  # misuse fails regardless of which way the flag happens to point.
+  #
+  # @example
+  #   false.then_some(:hello) # => None()
+  #   false.then_some { :hello } # => None()
+  #   false.then_some # => raise Errgonomic::ArgumentError, "then_some takes either a value or a block"
+  def then_some(*args, &block)
+    unless (args.length == 1 && !block) || (args.empty? && block)
+      raise Errgonomic::ArgumentError, 'then_some takes either a value or a block'
+    end
+
+    None()
+  end
+
+  # @example
+  #   false.ok_or(:ohno) # => Err(:ohno)
+  def ok_or(err)
+    Err(err)
+  end
+
+  # @example
+  #   false.ok_or_else { :ohno } # => Err(:ohno)
+  def ok_or_else(&block)
+    Err(block.call)
+  end
+end


### PR DESCRIPTION
Supersedes #14, keeping its API surface with one substitution.

## What's kept

`then_some`, `ok_or`, `ok_or_else` on `TrueClass`/`FalseClass` — anchored on Rust's `bool::then_some` (stable) and `bool::ok_or`/`ok_or_else` (nightly, green-lit for inclusion). Rust's `ok_or` returns `Result<(), E>`; Ruby has no unit type, so `Ok` carries `true`, noted in the docs.

## What's substituted

#14 also defined `then` — but `Kernel#then` is core Ruby (alias of `yield_self`), so that override changes existing behavior: `true.then { :x }` would return `Some(:x)` while `1.then { :x }` stays raw. Same line we drew for `Hash` in #38: additive only. Instead, `then_some` takes either a value or a block (`admin.then_some(:badge)` / `admin.then_some { badge! }`), raising pedantically on any other combination — validated on `false` too, so misuse fails regardless of which way the flag points.

## Bonus fix: 12 doctests were silently not running

While verifying, found the Rakefile's doctest pattern reaches yard through a shell whose `**` means `*`, so nothing under `lib/errgonomic/*/` was ever doctested — including #38's `Hash#fetch_option`/`Array#fetch_option` examples. First commit expands the glob in-process; the recovered doctests all pass (suite now at 109 doctest runs).

#14's second commit (`Option#xor`) already landed via #13.