### PR TITLE
Presence helpers now hand you the value inside the Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ An unhandled Option refuses to leak into your output: `to_s` and `to_json` raise
 
 Presence follows the discriminant, as in Rust: `Some` is `present?` and `None` is `blank?`, regardless of the wrapped value. So `Some(false).present?` and `Some(nil).present?` are both `true`. If you care about the inner value's own presence, unwrap it first.
 
+The presence helpers are soft-deprecated on Options in favor of the combinators. The present side unwraps, where on any other object it returns the receiver — `Some(v).present_or_raise!(msg)`, `present_or(default)`, `present_or_else { }`, and `presence` all yield `v`, and `None` raises, substitutes, or answers `nil` — and each call prints a one-line stderr nudge naming the combinator to use instead (`expect!`, `unwrap_or`, `unwrap_or_else`, `unwrap_or(nil)`). The blank side (`blank_or*`) raises `UnwrappedAccessError` outright: an Option's blankness is its discriminant, so test it with `none?`.
+
 Equality is between Options only: `Some(5) == Some(5)`, but `Some(5) == 5` and `None() == nil` are `false`. That is quiet, never an error, matching how every Ruby object compares across types. Rust rejects `Some(5) == 5` at compile time; Ruby cannot, so guard the idiom in review and tests: compare against a wrapped value (`opt == Some(5)`) or test the inner value (`opt.some_and? { |v| v == 5 }`).
 
 ### Result

--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -194,6 +194,114 @@ module Errgonomic
         none?
       end
 
+      # The presence helpers on Object keep their receiver; on an Option that
+      # would hand back the wrapper where the caller asked for a value. Here
+      # the present side unwraps instead, so a name that reads like an
+      # accessor behaves like one. The whole family is soft-deprecated on
+      # Options in favor of the combinators, so each call nudges via stderr,
+      # and the blank side, which has no working call sites to preserve,
+      # teaches rather than guesses at semantics.
+
+      # Returns the inner value of a Some, and raises on a None. Presence
+      # follows the discriminant, so Some(nil) yields nil.
+      #
+      # @param message [String] The error message to raise on a None.
+      # @return [Object] The inner value of a Some.
+      #
+      # @example
+      #   Some("secret").present_or_raise!("no secret") # => "secret"
+      #   Some(nil).present_or_raise!("no secret") # => nil
+      #   None().present_or_raise!("no secret") # => raise Errgonomic::NotPresentError, "no secret"
+      def present_or_raise!(message)
+        presence_nudge('present_or_raise', 'expect!')
+        raise Errgonomic::NotPresentError, message if none?
+
+        value
+      end
+
+      alias present_or_raise present_or_raise!
+
+      # Returns the inner value of a Some, and the given default on a None.
+      # No pedantic type check on the default: this family is deprecated on
+      # Options, and unwrap_or, which the nudge points to, has none either.
+      #
+      # @param default [Object] The value to return on a None.
+      # @return [Object] The inner value of a Some, otherwise the default.
+      #
+      # @example
+      #   Some("secret").present_or("fallback") # => "secret"
+      #   None().present_or("fallback") # => "fallback"
+      def present_or(default)
+        presence_nudge('present_or', 'unwrap_or')
+        return default if none?
+
+        value
+      end
+
+      # Returns the inner value of a Some, and the result of the block on a
+      # None.
+      #
+      # @param block [Proc] The block to call on a None.
+      # @return [Object] The inner value of a Some, otherwise the block's value.
+      #
+      # @example
+      #   Some("secret").present_or_else { "fallback" } # => "secret"
+      #   None().present_or_else { "fallback" } # => "fallback"
+      def present_or_else(&block)
+        presence_nudge('present_or_else', 'unwrap_or_else')
+        return block.call if none?
+
+        value
+      end
+
+      # Returns the inner value of a Some, and nil on a None, so the Rails
+      # +presence || default+ idiom reaches the value rather than the wrapper.
+      #
+      # @return [Object, nil] The inner value of a Some, otherwise nil.
+      #
+      # @example
+      #   Some("secret").presence # => "secret"
+      #   None().presence # => nil
+      #   None().presence || "fallback" # => "fallback"
+      def presence
+        presence_nudge('presence', 'unwrap_or(nil)')
+        return nil if none?
+
+        value
+      end
+
+      # @example the blank side of the presence family teaches the combinators
+      #   begin
+      #     None().blank_or("x")
+      #   rescue NoMethodError => e
+      #     e.class
+      #   end # => Errgonomic::UnwrappedAccessError
+      def blank_or(_default)
+        raise_blank_side_teaching(:blank_or)
+      end
+
+      # @example
+      #   begin
+      #     Some(1).blank_or_else { :x }
+      #   rescue NoMethodError => e
+      #     e.class
+      #   end # => Errgonomic::UnwrappedAccessError
+      def blank_or_else(&_block)
+        raise_blank_side_teaching(:blank_or_else)
+      end
+
+      # @example
+      #   begin
+      #     None().blank_or_raise!("msg")
+      #   rescue NoMethodError => e
+      #     e.class
+      #   end # => Errgonomic::UnwrappedAccessError
+      def blank_or_raise!(_message)
+        raise_blank_side_teaching(:blank_or_raise!)
+      end
+
+      alias blank_or_raise blank_or_raise!
+
       # return an Array with the contained value, if any
       # @example
       #   Some(1).to_a # => [1]
@@ -501,6 +609,21 @@ module Errgonomic
 
         None()
       end
+
+      private
+
+      def presence_nudge(from, to)
+        warn "Errgonomic: `#{from}` on an Option is soft-deprecated; prefer `#{to}`."
+      end
+
+      def raise_blank_side_teaching(name)
+        raise Errgonomic::UnwrappedAccessError.new(<<~MSG, name)
+          `#{name}` is not supported on an Option, whose blankness is its discriminant.
+          Test it with none?, or supply a fallback with unwrap_or / unwrap_or_else.
+        MSG
+      end
+
+      public
 
       # Rust's mutating combinators (insert, get_or_insert, take, replace)
       # are deliberately omitted: an Option here is a value, not a slot.

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -90,6 +90,20 @@ class BugTest < Minitest::Test
     assert author.name.present?
   end
 
+  # The presence helpers are how application code reaches a wrapped
+  # attribute's value, so they must yield the value and not the wrapper.
+  def test_wrapped_attribute_round_trips_through_present_or_raise
+    author = Author.create!(name: 'Cixin Liu', bio: 'writes sci-fi')
+    assert_equal 'writes sci-fi', author.bio.present_or_raise('no bio')
+    assert_equal 'writes sci-fi', author.bio.present_or('none given')
+    assert_equal 'writes sci-fi', author.bio.presence
+
+    unwritten = Author.create!(name: 'Liu Cixin')
+    assert_raises(Errgonomic::NotPresentError) { unwritten.bio.present_or_raise('no bio') }
+    assert_equal 'none given', unwritten.bio.present_or('none given')
+    assert_nil unwritten.bio.presence
+  end
+
   def test_optional_associations
     author = Author.create!(name: 'Cixin Liu')
     book = author.books.create!(title: 'The Dark Forest')


### PR DESCRIPTION
Fixes #42.

Before, `present_or_raise` gave you back the whole box instead of the thing inside it. The error check worked, so it looked right. But the value you got was the wrong shape, and nothing told you. Now these helpers open the box and hand you the value. They also print a small note saying which newer method to use instead, because these old helpers are on their way out for Options.

## Detail

- Present side (`present_or_raise!`/`present_or_raise`, `present_or`, `present_or_else`, `presence`) unwraps: `Some(v)` yields `v` (including `Some(nil)` → `nil`, presence follows the discriminant), `None` raises `NotPresentError` / returns the default / calls the block / answers `nil`. So `opt.presence || default` reaches the value.
- The whole family is **soft-deprecated on Options** in favor of the combinators: each present-side call nudges via stderr toward `expect!`, `unwrap_or`, `unwrap_or_else`, or `unwrap_or(nil)`. The pedantic type check on `present_or`'s default is dropped on Options; `unwrap_or` has none either.
- The blank side (`blank_or`, `blank_or_else`, `blank_or_raise!`) raises `UnwrappedAccessError` teaching `none?`/`unwrap_or`. It had zero working call sites to preserve: `blank_or`'s inherited type check always raised on Options, and the other two returned the wrapper.

Specified as doctests; a Rails test covers a wrapped attribute round-tripping through `present_or_raise` to the raw value.