### PR TITLE
Options hiding inside JSON now fail loudly

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ in Errgonomic::Option::None
 end
 ```
 
-An unhandled Option refuses to leak into your output: `to_s` and `to_json` raise `Errgonomic::SerializeError`, so you handle the inner value deliberately rather than shipping `#<Errgonomic::Option::Some...>` to a user.
+An unhandled Option refuses to leak into your output: `to_s`, `to_json`, and `as_json` raise `Errgonomic::SerializeError`, so you handle the inner value deliberately rather than shipping `#<Errgonomic::Option::Some...>` to a user. The refusal covers `as_json` because Hash and Array serialization recurses through that method, and an Option nested in a payload would otherwise serialize as `{"value": ...}`.
 
 `unwrap!` and `expect!` are for tests and consoles, not application code: they raise on `None`, which is exactly the ambiguous failure the type exists to prevent. Application code should always have a combinator or pattern match that handles the `None` branch explicitly; if none fits, that is a gap worth an issue rather than a reason to unwrap.
 
@@ -148,7 +148,7 @@ in Errgonomic::Result::Err, Exception => e
 end
 ```
 
-Like Options, unwrapped Results refuse `to_s` and `to_json`. And `Object#result?` / `Object#assert_result!` help enforce at runtime that a value is a Result.
+Like Options, unwrapped Results refuse `to_s`, `to_json`, and `as_json`. And `Object#result?` / `Object#assert_result!` help enforce at runtime that a value is a Result.
 
 ### Optional collections
 

--- a/lib/errgonomic/option.rb
+++ b/lib/errgonomic/option.rb
@@ -556,6 +556,15 @@ module Errgonomic
         raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Option'
       end
 
+      # ActiveSupport's Hash#as_json and Array#as_json recurse through their
+      # members with as_json rather than to_json, so an Option nested in a
+      # payload reaches Object#as_json and serializes as its instance
+      # variables. Refuse there too, and the guard holds wherever an Option
+      # travels.
+      def as_json(*_args)
+        raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Option'
+      end
+
       # pp uses its own object dump unless told otherwise; keep it consistent
       # with inspect.
       def pretty_print(pp)

--- a/lib/errgonomic/result.rb
+++ b/lib/errgonomic/result.rb
@@ -369,6 +369,15 @@ module Errgonomic
         raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Result'
       end
 
+      # ActiveSupport's Hash#as_json and Array#as_json recurse through their
+      # members with as_json rather than to_json, so a Result nested in a
+      # payload reaches Object#as_json and serializes as its instance
+      # variables. Refuse there too, and the guard holds wherever a Result
+      # travels.
+      def as_json(*_args)
+        raise Errgonomic::SerializeError, 'cannot serialize an unwrapped Result'
+      end
+
       # pp uses its own object dump unless told otherwise; keep it consistent
       # with inspect.
       def pretty_print(pp)

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -168,6 +168,18 @@ class BugTest < Minitest::Test
     refute_includes relation.to_sql, 'NULL'
   end
 
+  # Hash and Array serialization recurses with as_json, never to_json, so
+  # the refusal has to sit on as_json to survive nesting.
+  def test_nested_options_and_results_refuse_to_serialize
+    assert_raises(Errgonomic::SerializeError) { Some(5).as_json }
+    assert_raises(Errgonomic::SerializeError) { { a: Some(5) }.to_json }
+    assert_raises(Errgonomic::SerializeError) { { a: None() }.to_json }
+    assert_raises(Errgonomic::SerializeError) { [Some(5)].to_json }
+    assert_raises(Errgonomic::SerializeError) { Ok(5).as_json }
+    assert_raises(Errgonomic::SerializeError) { { a: Err(5) }.to_json }
+    assert_raises(Errgonomic::SerializeError) { [Ok(5)].to_json }
+  end
+
   def test_delegate_optional
     author = Author.create!(name: 'Cixin Liu')
     book = author.books.create!(title: 'Death\'s End')


### PR DESCRIPTION
Fixes #43.

An Option at the top level already refuses to turn into JSON: it raises an error. But an Option hiding inside a hash or an array slipped through, and came out as strange JSON like `{"value":5}`. A missing value came out as `{}`. No error, no warning. Now it raises the same loud error no matter how deeply it is buried.

## Detail

- `as_json` on `Option::Any` and `Result::Any` raises `SerializeError` with the same messages as `to_s`/`to_json`. ActiveSupport's `Hash#as_json`/`Array#as_json` recurse via `as_json`, never `to_json`, which is how the existing guard was bypassed.
- Result had the identical hole (`Ok(5).as_json => {"value"=>5}`), not mentioned in the issue; fixed alongside.
- Defining `as_json` without ActiveSupport loaded is harmless, so it is unconditional.

Covered in `test/rails_test.rb` (hash and array nesting, Option and Result) rather than doctests, since doctests run without ActiveSupport.