### PR TITLE
Read a has_one as an Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ end
 
 When `Rails::Railtie` is defined, Errgonomic installs a Railtie with two opt-in integrations for ActiveRecord:
 
-- `include Errgonomic::Rails::ActiveRecordOptional` in a model makes its nullable attributes and `optional: true` associations return `Some(value)` or `None()` instead of a value-or-nil. Every nullable column and optional association is wrapped, with no per-attribute opt-in. Two kinds of attribute stay unwrapped: those declared with `encrypts`, whose surrounding machinery reads the raw value, and those named by `errgonomic_optional_except`.
+- `include Errgonomic::Rails::ActiveRecordOptional` in a model makes its nullable attributes and `optional: true` associations return `Some(value)` or `None()` instead of a value-or-nil. Every nullable column and optional association is wrapped, with no per-attribute opt-in. Three kinds of reader stay unwrapped: attributes declared with `encrypts` and singular associations with `accepts_nested_attributes_for`, both of which ActiveRecord's own machinery reads raw, and anything named by `errgonomic_optional_except`.
 
 ```ruby
 class Credential < ApplicationRecord
@@ -209,6 +209,8 @@ class Credential < ApplicationRecord
   include Errgonomic::Rails::ActiveRecordOptional
 
   encrypts :access_secret   # also left unwrapped, declared either side of the include
+  has_one :rotation_schedule # wrapped: Some(schedule) or None()
+  has_one :owner, required: true # left unwrapped: absence is a validation failure
 end
 ```
 

--- a/lib/errgonomic/rails/active_record_optional.rb
+++ b/lib/errgonomic/rails/active_record_optional.rb
@@ -33,6 +33,9 @@ module Errgonomic
         reflect_on_all_associations(:belongs_to)
           .select { |r| r.options[:optional] }
           .each { |r| errgonomic_wrap_optional(r.name) }
+        reflect_on_all_associations(:has_one)
+          .reject { |r| r.options[:required] }
+          .each { |r| errgonomic_wrap_optional(r.name) }
       end
 
       class_methods do
@@ -114,6 +117,14 @@ module Errgonomic
         # Wrap it when it arrives, or the conversion is silently partial.
         def belongs_to(name, scope = nil, **options)
           super.tap { errgonomic_wrap_optional(name) if options[:optional] }
+        end
+
+        # A has_one is absent whenever no row points back at the record, so
+        # its reader carries the same absence a nullable column does.
+        # required: true is the exception: it asserts the record is there, and
+        # absence is a validation failure rather than a value to handle.
+        def has_one(name, scope = nil, **options)
+          super.tap { errgonomic_wrap_optional(name) unless options[:required] }
         end
 
         # Encryption surrounds an attribute with machinery that reads the raw

--- a/lib/errgonomic/rails/active_record_optional.rb
+++ b/lib/errgonomic/rails/active_record_optional.rb
@@ -19,9 +19,11 @@ module Errgonomic
     #    boundary, so an Option can be passed to where/quote.
     # 4. SomeValidator provides a presence-style validation for Option
     #    attributes.
-    # 5. Attributes declared with encrypts are never wrapped: ActiveRecord
-    #    Encryption registers a length validator outside Model.validators
-    #    that reads the raw value and cannot survive an Option.
+    # 5. Readers that ActiveRecord's own machinery reads raw are never
+    #    wrapped: an attribute declared with encrypts, whose length validator
+    #    sits outside Model.validators and calls to_s on the value, and a
+    #    singular association with nested attributes, which are assigned
+    #    through the reader and ask the value whether it is a new record.
     #
     # errgonomic_optional_except is not on the list: it is configuration, an
     # escape hatch for whatever conflict shows up next, not a semantic
@@ -64,7 +66,10 @@ module Errgonomic
                         []
                       end
 
-          inherited | Array(encrypted_attributes).map(&:to_s) | Array(try(:errgonomic_optional_exceptions)).map(&:to_s)
+          inherited |
+            Array(encrypted_attributes).map(&:to_s) |
+            Array(try(:errgonomic_optional_exceptions)).map(&:to_s) |
+            errgonomic_nested_attribute_associations
         end
 
         # A model that keeps value-or-nil throughout, for whatever the
@@ -125,6 +130,24 @@ module Errgonomic
         # absence is a validation failure rather than a value to handle.
         def has_one(name, scope = nil, **options)
           super.tap { errgonomic_wrap_optional(name) unless options[:required] }
+        end
+
+        # Nested attributes are assigned through the public reader, and
+        # ActiveRecord asks whatever it finds there whether it is a new
+        # record. An absent association has to arrive as nil for that, so a
+        # singular association with nested attributes keeps its plain reader.
+        def accepts_nested_attributes_for(*names, **options)
+          super.tap { errgonomic_unwrap_optionals(*names) }
+        end
+
+        # ActiveRecord keeps its own register of these, so the exclusion can be
+        # read from there rather than recorded as it goes past.
+        def errgonomic_nested_attribute_associations
+          return [] unless respond_to?(:nested_attributes_options)
+
+          nested_attributes_options.keys.map(&:to_s).select do |name|
+            %i[has_one belongs_to].include?(reflect_on_association(name)&.macro)
+          end
         end
 
         # Encryption surrounds an attribute with machinery that reads the raw

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -32,6 +32,18 @@ ActiveRecord::Schema.define do
     t.timestamps
   end
 
+  create_table 'profiles', force: :cascade do |t|
+    t.string :tagline
+    t.references :author
+    t.timestamps
+  end
+
+  create_table 'awards', force: :cascade do |t|
+    t.string :name, null: false
+    t.references :author
+    t.timestamps
+  end
+
   create_table 'magazines', force: :cascade do |t|
     t.string :title, null: false
     t.string :issn
@@ -56,7 +68,25 @@ Errgonomic::Rails.setup_before
 
 class Author < ActiveRecord::Base
   has_many :books
+  has_one :profile, dependent: :destroy
   include Errgonomic::Rails::ActiveRecordOptional
+  has_one :award, dependent: :destroy
+end
+
+class Profile < ActiveRecord::Base
+  belongs_to :author
+end
+
+class Award < ActiveRecord::Base
+  belongs_to :author
+end
+
+# A has_one declared required asserts the record is there, so its reader is
+# left alone: absence is a validation failure rather than a value.
+class Publisher < ActiveRecord::Base
+  self.table_name = 'authors'
+  include Errgonomic::Rails::ActiveRecordOptional
+  has_one :profile, required: true, foreign_key: :author_id
 end
 
 class Book < ActiveRecord::Base
@@ -317,6 +347,45 @@ class BugTest < Minitest::Test
     end
 
     assert_equal %w[issn], quarterly.errgonomic_optionals
+  end
+
+  # A has_one is absent whenever no row points back, so its reader carries
+  # the same absence a nullable column does, whichever side of the include
+  # it is declared on.
+  def test_has_one_reads_as_an_option
+    author = Author.create!(name: 'Cixin Liu')
+
+    assert author.profile.none?
+    assert author.award.none?
+
+    author.create_profile!(tagline: 'writes sci-fi')
+    author.create_award!(name: 'Hugo')
+
+    assert_equal 'writes sci-fi', author.reload.profile.unwrap!.tagline
+    assert_equal 'Hugo', author.award.unwrap!.name
+  end
+
+  # Absence is representable, so the association's own machinery has to keep
+  # working through the wrapper.
+  def test_has_one_writes_and_dependent_destroy_still_work
+    author = Author.create!(name: 'Cixin Liu')
+    author.profile = Profile.new(tagline: 'writes sci-fi')
+    author.save!
+
+    assert_equal 'writes sci-fi', author.reload.profile.unwrap!.tagline
+
+    author.destroy!
+
+    assert_equal 0, Profile.where(author_id: author.id).count
+  end
+
+  # required: true says the record is always there, which is a validation,
+  # not an absence to represent.
+  def test_a_required_has_one_is_left_unwrapped
+    publisher = Publisher.create!(name: 'Tor', profile: Profile.new(tagline: 'imprint'))
+
+    assert_equal 'imprint', publisher.reload.profile.tagline
+    assert_raises(ActiveRecord::RecordInvalid) { Publisher.create!(name: 'Baen') }
   end
 
   # An inherited reader is already wrapped, and a second wrap nests: Some of

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -127,6 +127,23 @@ class Credential < ActiveRecord::Base
   encrypts :access_secret
 end
 
+# Nested attributes are assigned through the public reader, and ActiveRecord
+# asks whatever it finds there whether it is a new record, so a wrapped
+# singular association cannot survive the round trip.
+class Editor < ActiveRecord::Base
+  self.table_name = 'authors'
+  include Errgonomic::Rails::ActiveRecordOptional
+  has_one :profile, foreign_key: :author_id
+  accepts_nested_attributes_for :profile, allow_destroy: true
+end
+
+class Anthology < ActiveRecord::Base
+  self.table_name = 'books'
+  include Errgonomic::Rails::ActiveRecordOptional
+  belongs_to :author, optional: true
+  accepts_nested_attributes_for :author
+end
+
 # An opt-out named before the include keeps an attribute unwrapped, for
 # machinery the concern does not know about.
 class OptedOutCredential < ActiveRecord::Base
@@ -377,6 +394,39 @@ class BugTest < Minitest::Test
     author.destroy!
 
     assert_equal 0, Profile.where(author_id: author.id).count
+  end
+
+  # ActiveRecord reads the association, asks it whether it is a new record,
+  # and assigns through it, so the reader has to stay plain for the whole
+  # nested-attributes cycle: build, update, and destroy.
+  def test_nested_attributes_on_a_has_one_keep_working
+    editor = Editor.create!(name: 'Cixin Liu')
+
+    editor.update!(profile_attributes: { tagline: 'writes sci-fi' })
+
+    assert_equal 'writes sci-fi', editor.reload.profile.tagline
+
+    editor.update!(profile_attributes: { id: editor.profile.id, tagline: 'revised' })
+
+    assert_equal 'revised', editor.reload.profile.tagline
+
+    editor.update!(profile_attributes: { id: editor.profile.id, _destroy: '1' })
+
+    assert_nil editor.reload.profile
+  end
+
+  def test_nested_attributes_on_an_optional_belongs_to_keep_working
+    anthology = Anthology.create!(title: 'Wandering Earth', author_attributes: { name: 'Cixin Liu' })
+
+    assert_equal 'Cixin Liu', anthology.reload.author.name
+  end
+
+  # The unwrapped set is discoverable, so a converted model can say which
+  # readers ActiveRecord kept for itself.
+  def test_an_association_with_nested_attributes_is_reported_as_unwrapped
+    refute_includes Editor.errgonomic_optionals, 'profile'
+    refute_includes Anthology.errgonomic_optionals, 'author'
+    assert_includes Anthology.errgonomic_optional_exclusions, 'author'
   end
 
   # required: true says the record is always there, which is a validation,


### PR DESCRIPTION
Second of the stack, on top of #52. `nz/nested-attributes-unwrap` and `nz/cheap-recursion-guard` follow.

## A has_one carries the same absence a nullable column does

A `has_one` is absent whenever no row points back at the record, which is the same kind of absence a nullable column carries. Before this, a converted model answered in two dialects: an Option from its columns and its `optional: true` `belongs_to`, and a bare `nil` from its `has_one`. A caller had to know which reader spoke which, and the compromise the concern documents — `None#nil?` answers true so ordinary nil checks keep working — quietly papered over the difference until something reached for a combinator.

```ruby
class Author < ApplicationRecord
  include Errgonomic::Rails::ActiveRecordOptional

  has_one :profile          # Some(profile) or None()
  has_one :owner, required: true   # left alone
end
```

`required: true` is the exception. It asserts the record is there, so absence is a validation failure rather than a value for a caller to handle, and the reader stays plain.

## Absence being representable does not excuse breaking the association

The wrapped reader has to keep the association's own machinery working, so the tests cover more than reading:

- reading an absent and a present `has_one`, declared on either side of the include
- `create_profile!` and direct assignment followed by `save!`
- `dependent: :destroy` still destroying the child
- a `required: true` `has_one` staying unwrapped, and still failing validation when its record is missing

`accepts_nested_attributes_for` on a `has_one` does **not** survive this, for the same reason it does not survive on an `optional: true belongs_to`: ActiveRecord assigns through the public reader and asks the value whether it is a new record. That is a pre-existing defect rather than something this PR introduces, and `nz/nested-attributes-unwrap` is next in the stack because of it.

## Testing

`rake` — 27 tests, 71 assertions, and 118 doctests, all passing.
