### PR TITLE
Lifting an Option with to_option returns it unchanged

### DIFF
--- a/lib/errgonomic/rails/active_record_optional.rb
+++ b/lib/errgonomic/rails/active_record_optional.rb
@@ -224,6 +224,18 @@ class Object
 end
 
 module Errgonomic
+  module Option
+    # An Option is already lifted. Lifting it again would nest it, and the
+    # nesting is invisible until something reaches for the inner value.
+    class Any
+      def to_option
+        self
+      end
+    end
+  end
+end
+
+module Errgonomic
   module Rails
     # Teach ActiveRecord SQL quoting to unwrap Options, quoting a None as
     # SQL NULL.

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -244,6 +244,26 @@ class BugTest < Minitest::Test
     assert_raises(Errgonomic::SerializeError) { [Ok(5)].to_json }
   end
 
+  # to_option lifts a value that may be nil. An Option is already lifted, and
+  # a second lift nests invisibly: Some(Some(x)) still answers some?, so the
+  # mistake surfaces far from where it was made.
+  def test_to_option_is_idempotent
+    assert_equal Some(1), Some(1).to_option
+    assert_equal 1, Some(1).to_option.unwrap!
+    assert None().to_option.none?
+  end
+
+  # The shape an application reaches for around an unwrapped association:
+  # lift it, then reach through it for an attribute that is already an Option.
+  def test_to_option_composes_through_an_unwrapped_association
+    author = Author.create!(name: 'Cixin Liu', bio: 'writes sci-fi')
+    shelved = Book.create!(title: 'The Dark Forest', author_id: author.id)
+    unshelved = Book.create!(title: 'Supernova Era')
+
+    assert_equal 'writes sci-fi', shelved.author.to_option.and_then(&:bio).unwrap_or('unknown')
+    assert_equal 'unknown', unshelved.author.to_option.and_then(&:bio).unwrap_or('unknown')
+  end
+
   def test_delegate_optional
     author = Author.create!(name: 'Cixin Liu')
     book = author.books.create!(title: 'Death\'s End')


### PR DESCRIPTION
Independent of the #53 → #54 → #55 stack; reviewable on its own.

## Lifting an Option nested it

`to_option` lifts a value that may be nil. An Option is already lifted, so a second lift produced `Some(Some(x))`, which still answers `some?` and unwraps to an Option. Nothing raised at the lift; the mistake surfaced wherever something later reached for the inner value.

```ruby
Some(1).to_option   # was Some(Some(1)), now Some(1)
None().to_option    # was Some(None), now None()
```

## Where it shows up

Wherever a wrapped source meets an unwrapped one, which is every partially converted application. The idiom that hits it is lifting an association that returns nil today and then reaching through it for an attribute that is already an Option:

```ruby
widget.widget_snapshot.to_option.and_then(&:data).unwrap_or({})
```

If `widget_snapshot` is a plain record that reads fine. Once the model on the other side converts, the same line double-wraps and `and_then` hands `Some(record)` to a block that expects the record — `Errgonomic::UnwrappedAccessError`, far from the lift that caused it. The second test in this PR is exactly that shape, and it fails without the fix.

## Testing

`rake` — 26 tests, 68 assertions, and 118 doctests, all passing.
